### PR TITLE
Change to use Bundler.root instead of Pathname.pwd

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-packs (0.0.14)
+    rubocop-packs (0.0.15)
       activesupport
       parse_packwerk
       rubocop

--- a/lib/rubocop/packs/private.rb
+++ b/lib/rubocop/packs/private.rb
@@ -20,7 +20,7 @@ module RuboCop
         return if @loaded_client_configuration
 
         @loaded_client_configuration = true
-        client_configuration = Pathname.pwd.join('config/rubocop_packs.rb')
+        client_configuration = Bundler.root.join('config/rubocop_packs.rb')
         require client_configuration.to_s if client_configuration.exist?
       end
 

--- a/rubocop-packs.gemspec
+++ b/rubocop-packs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'rubocop-packs'
-  spec.version       = '0.0.14'
+  spec.version       = '0.0.15'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'Fill this out!'


### PR DESCRIPTION
`Pathname.pwd` is not what is expected when evaluated within the context of an evaluated ERB. `Bundler.root` is more accurate here, although I also think it might be good to just lean on `rubocop` requires: https://docs.rubocop.org/rubocop/extensions.html#loading-extensions