### PR TITLE
Permit packs/*/.rubocop.yml to specify an `inherit_from` key

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-packs (0.0.15)
+    rubocop-packs (0.0.16)
       activesupport
       parse_packwerk
       rubocop

--- a/lib/rubocop/packs/private.rb
+++ b/lib/rubocop/packs/private.rb
@@ -85,6 +85,8 @@ module RuboCop
         end
 
         loaded_rubocop_yml.each_key do |key|
+          next if key.to_s == 'inherit_from'
+
           if !Packs.config.permitted_pack_level_cops.include?(key)
             errors << <<~ERROR_MESSAGE
               #{rubocop_yml} contains invalid configuration for #{key}.

--- a/rubocop-packs.gemspec
+++ b/rubocop-packs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'rubocop-packs'
-  spec.version       = '0.0.15'
+  spec.version       = '0.0.16'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'Fill this out!'

--- a/spec/rubocop/packs_spec.rb
+++ b/spec/rubocop/packs_spec.rb
@@ -236,6 +236,20 @@ RSpec.describe RuboCop::Packs do
           expect(errors).to eq([error])
         end
       end
+
+      context 'one pack with inherit_from set' do
+        before do
+          write_package_yml('packs/some_pack')
+
+          write_file('packs/some_pack/.rubocop.yml', <<~YML)
+            inherit_from: "../../.base_rubocop.yml"
+          YML
+        end
+
+        it 'has no errors' do
+          expect(errors).to be_empty
+        end
+      end
     end
 
     describe 'pack based .rubocop.yml files' do


### PR DESCRIPTION
This is necessary so packs can inherit from the parent `.rubocop.yml`.
