### PR TITLE
Improve messaging and naming of cops

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-packs (0.0.16)
+    rubocop-packs (0.0.17)
       activesupport
       parse_packwerk
       rubocop

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ All cops are located under [`lib/rubocop/cop/packs`](lib/rubocop/cop/packs), and
 In your `.rubocop.yml`, you may treat the Packs cops just like any other cop. For example:
 
 ```yaml
-Packs/NamespaceConvention:
+Packs/RootNamespaceIsPackName:
   Exclude:
     - lib/example.rb
 ```
@@ -70,8 +70,8 @@ To use per-pack `.rubocop.yml` and `.rubocop_todo.yml` files, you need to config
 ```ruby
 # config/rubocop_packs.rb
 RuboCop::Packs.configure do |config|
-  config.permitted_pack_level_cops = ['Packs/NamespaceConvention']
-  config.required_pack_level_cops = ['Packs/NamespaceConvention']
+  config.permitted_pack_level_cops = ['Packs/RootNamespaceIsPackName']
+  config.required_pack_level_cops = ['Packs/RootNamespaceIsPackName']
 end
 ```
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -14,7 +14,7 @@ Packs/RootNamespaceIsPackName:
 Packs/TypedPublicApis:
   Enabled: true
 
-Packs/RequireDocumentedPublicApis:
+Packs/DocumentedPublicApis:
   Enabled: true
 
 PackwerkLite/Privacy:

--- a/config/default.yml
+++ b/config/default.yml
@@ -8,7 +8,7 @@ Packs/ClassMethodsAsPublicApis:
     - Struct
     - OpenStruct
 
-Packs/NamespaceConvention:
+Packs/RootNamespaceIsPackName:
   Enabled: true
 
 Packs/TypedPublicApi:

--- a/config/default.yml
+++ b/config/default.yml
@@ -11,7 +11,7 @@ Packs/ClassMethodsAsPublicApis:
 Packs/RootNamespaceIsPackName:
   Enabled: true
 
-Packs/TypedPublicApi:
+Packs/TypedPublicApis:
   Enabled: true
 
 Packs/RequireDocumentedPublicApis:

--- a/docs/packwerk_lite.md
+++ b/docs/packwerk_lite.md
@@ -1,6 +1,6 @@
 # [PackwerkLite](/lib/rubocop/cop/packwerk_lite)
 
-This is a proof-of-concept for Packwerk Lite, an implementation of Packwerk that is made simpler by assuming the application adheres to [`Packs/NamespaceConvention`](/lib/rubocop/cop/packs/namespace_convention.rb).
+This is a proof-of-concept for Packwerk Lite, an implementation of Packwerk that is made simpler by assuming the application adheres to [`Packs/RootNamespaceIsPackName`](/lib/rubocop/cop/packs/namespace_convention.rb).
 
 [`PackwerkLite/Privacy`](/lib/rubocop/cop/packwerk_lite/privacy_checker.rb)
 

--- a/lib/rubocop-packs.rb
+++ b/lib/rubocop-packs.rb
@@ -11,6 +11,6 @@ require_relative 'rubocop/packwerk_lite'
 require 'rubocop/cop/packs/root_namespace_is_pack_name'
 require 'rubocop/cop/packs/typed_public_apis'
 require 'rubocop/cop/packs/class_methods_as_public_apis'
-require 'rubocop/cop/packs/require_documented_public_apis'
+require 'rubocop/cop/packs/documented_public_apis'
 
 RuboCop::Packs::Inject.defaults!

--- a/lib/rubocop-packs.rb
+++ b/lib/rubocop-packs.rb
@@ -9,7 +9,7 @@ require_relative 'rubocop/packs/inject'
 require_relative 'rubocop/packwerk_lite'
 
 require 'rubocop/cop/packs/root_namespace_is_pack_name'
-require 'rubocop/cop/packs/typed_public_api'
+require 'rubocop/cop/packs/typed_public_apis'
 require 'rubocop/cop/packs/class_methods_as_public_apis'
 require 'rubocop/cop/packs/require_documented_public_apis'
 

--- a/lib/rubocop-packs.rb
+++ b/lib/rubocop-packs.rb
@@ -8,7 +8,7 @@ require_relative 'rubocop/packs'
 require_relative 'rubocop/packs/inject'
 require_relative 'rubocop/packwerk_lite'
 
-require 'rubocop/cop/packs/namespace_convention'
+require 'rubocop/cop/packs/root_namespace_is_pack_name'
 require 'rubocop/cop/packs/typed_public_api'
 require 'rubocop/cop/packs/class_methods_as_public_apis'
 require 'rubocop/cop/packs/require_documented_public_apis'

--- a/lib/rubocop/cop/packs/class_methods_as_public_apis.rb
+++ b/lib/rubocop/cop/packs/class_methods_as_public_apis.rb
@@ -55,7 +55,7 @@ module RuboCop
           add_offense(
             node.source_range,
             message: format(
-              'Top-level files in the public/ folder may only define class methods.'
+              "Public API method must be a class method (e.g. `self.#{node.method_name}(...)`)"
             )
           )
         end

--- a/lib/rubocop/cop/packs/documented_public_apis.rb
+++ b/lib/rubocop/cop/packs/documented_public_apis.rb
@@ -21,7 +21,7 @@ module RuboCop
       #     def bar; end
       #   end
       #
-      class RequireDocumentedPublicApis < Style::DocumentationMethod
+      class DocumentedPublicApis < Style::DocumentationMethod
         # This cop does two things:
         # 1) It only activates for things in the public folder
         # 2) It allows `Style/DocumentationMethod` to work with sigs as expected.

--- a/lib/rubocop/cop/packs/root_namespace_is_pack_name.rb
+++ b/lib/rubocop/cop/packs/root_namespace_is_pack_name.rb
@@ -2,7 +2,7 @@
 
 # For String#camelize
 require 'active_support/core_ext/string/inflections'
-require 'rubocop/cop/packs/namespace_convention/desired_zeitwerk_api'
+require 'rubocop/cop/packs/root_namespace_is_pack_name/desired_zeitwerk_api'
 
 module RuboCop
   module Cop
@@ -23,7 +23,7 @@ module RuboCop
       #   # packs/foo/app/services/foo/blah/bar.rb
       #   class Foo::Blah::Bar; end
       #
-      class NamespaceConvention < Base
+      class RootNamespaceIsPackName < Base
         extend T::Sig
 
         include RangeHelp

--- a/lib/rubocop/cop/packs/root_namespace_is_pack_name/desired_zeitwerk_api.rb
+++ b/lib/rubocop/cop/packs/root_namespace_is_pack_name/desired_zeitwerk_api.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Packs
-      class NamespaceConvention < Base
+      class RootNamespaceIsPackName < Base
         #
         # This is a private class that represents API that we would prefer to be available somehow in Zeitwerk.
         # However, the boundaries between systems (packwerk/zeitwerk, rubocop/zeitwerk) are poor in this class, so

--- a/lib/rubocop/cop/packs/typed_public_apis.rb
+++ b/lib/rubocop/cop/packs/typed_public_apis.rb
@@ -19,7 +19,7 @@ module RuboCop
       #   # typed: strict
       #   module Foo; end
       #
-      class TypedPublicApi < Sorbet::StrictSigil
+      class TypedPublicApis < Sorbet::StrictSigil
         #
         # This inherits from `Sorbet::StrictSigil` and doesn't change any behavior of it.
         # The only reason we do this is so that configuration for this cop can live under a different cop namespace.

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -2,7 +2,7 @@
 #### Department [Packs](cops_packs.md)
 
 * [Packs/ClassMethodsAsPublicApis](cops_packs.md#packsclassmethodsaspublicapis)
-* [Packs/RequireDocumentedPublicApis](cops_packs.md#packsrequiredocumentedpublicapis)
+* [Packs/DocumentedPublicApis](cops_packs.md#packsdocumentedpublicapis)
 * [Packs/RootNamespaceIsPackName](cops_packs.md#packsrootnamespaceispackname)
 * [Packs/TypedPublicApis](cops_packs.md#packstypedpublicapis)
 

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -2,8 +2,8 @@
 #### Department [Packs](cops_packs.md)
 
 * [Packs/ClassMethodsAsPublicApis](cops_packs.md#packsclassmethodsaspublicapis)
-* [Packs/NamespaceConvention](cops_packs.md#packsnamespaceconvention)
 * [Packs/RequireDocumentedPublicApis](cops_packs.md#packsrequiredocumentedpublicapis)
+* [Packs/RootNamespaceIsPackName](cops_packs.md#packsrootnamespaceispackname)
 * [Packs/TypedPublicApi](cops_packs.md#packstypedpublicapi)
 
 <!-- END_COP_LIST -->

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -4,6 +4,6 @@
 * [Packs/ClassMethodsAsPublicApis](cops_packs.md#packsclassmethodsaspublicapis)
 * [Packs/RequireDocumentedPublicApis](cops_packs.md#packsrequiredocumentedpublicapis)
 * [Packs/RootNamespaceIsPackName](cops_packs.md#packsrootnamespaceispackname)
-* [Packs/TypedPublicApi](cops_packs.md#packstypedpublicapi)
+* [Packs/TypedPublicApis](cops_packs.md#packstypedpublicapis)
 
 <!-- END_COP_LIST -->

--- a/manual/cops_packs.md
+++ b/manual/cops_packs.md
@@ -87,7 +87,7 @@ class Blah::Bar; end
 class Foo::Blah::Bar; end
 ```
 
-## Packs/TypedPublicApi
+## Packs/TypedPublicApis
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---

--- a/manual/cops_packs.md
+++ b/manual/cops_packs.md
@@ -37,7 +37,7 @@ Name | Default value | Configurable values
 --- | --- | ---
 AcceptableParentClasses | `T::Enum`, `T::Struct`, `Struct`, `OpenStruct` | Array
 
-## Packs/RequireDocumentedPublicApis
+## Packs/DocumentedPublicApis
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---

--- a/manual/cops_packs.md
+++ b/manual/cops_packs.md
@@ -37,30 +37,6 @@ Name | Default value | Configurable values
 --- | --- | ---
 AcceptableParentClasses | `T::Enum`, `T::Struct`, `Struct`, `OpenStruct` | Array
 
-## Packs/NamespaceConvention
-
-Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
---- | --- | --- | --- | ---
-Enabled | Yes | No | - | -
-
-This cop helps ensure that each pack exposes one namespace.
-Note that this cop doesn't necessarily expect you to be using stimpack (https://github.com/rubyatscale/stimpack),
-but it does expect packs to live in the organizational structure as described in the README.md of that gem.
-
-This allows packs to opt in and also prevent *other* files from sitting in their namespace.
-
-### Examples
-
-```ruby
-# bad
-# packs/foo/app/services/blah/bar.rb
-class Blah::Bar; end
-
-# good
-# packs/foo/app/services/foo/blah/bar.rb
-class Foo::Blah::Bar; end
-```
-
 ## Packs/RequireDocumentedPublicApis
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
@@ -85,6 +61,30 @@ class Foo
   # It can live below or below a sorbet type signature.
   def bar; end
 end
+```
+
+## Packs/RootNamespaceIsPackName
+
+Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+--- | --- | --- | --- | ---
+Enabled | Yes | No | - | -
+
+This cop helps ensure that each pack exposes one namespace.
+Note that this cop doesn't necessarily expect you to be using stimpack (https://github.com/rubyatscale/stimpack),
+but it does expect packs to live in the organizational structure as described in the README.md of that gem.
+
+This allows packs to opt in and also prevent *other* files from sitting in their namespace.
+
+### Examples
+
+```ruby
+# bad
+# packs/foo/app/services/blah/bar.rb
+class Blah::Bar; end
+
+# good
+# packs/foo/app/services/foo/blah/bar.rb
+class Foo::Blah::Bar; end
 ```
 
 ## Packs/TypedPublicApi

--- a/rubocop-packs.gemspec
+++ b/rubocop-packs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'rubocop-packs'
-  spec.version       = '0.0.16'
+  spec.version       = '0.0.17'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'Fill this out!'

--- a/spec/rubocop/cop/packs/class_methods_as_public_apis_spec.rb
+++ b/spec/rubocop/cop/packs/class_methods_as_public_apis_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe RuboCop::Cop::Packs::ClassMethodsAsPublicApis, :config do
       <<~RUBY
         class Tool
           def my_instance_method
-          ^^^^^^^^^^^^^^^^^^^^^^ Top-level files in the public/ folder may only define class methods.
+          ^^^^^^^^^^^^^^^^^^^^^^ Public API method must be a class method (e.g. `self.my_instance_method(...)`)
           end
         end
       RUBY
@@ -53,7 +53,7 @@ RSpec.describe RuboCop::Cop::Packs::ClassMethodsAsPublicApis, :config do
 
           sig { params(id: Integer).void }
           def my_instance_method(id)
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^ Top-level files in the public/ folder may only define class methods.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^ Public API method must be a class method (e.g. `self.my_instance_method(...)`)
           end
         end
       RUBY

--- a/spec/rubocop/cop/packs/documented_public_apis_spec.rb
+++ b/spec/rubocop/cop/packs/documented_public_apis_spec.rb
@@ -1,6 +1,6 @@
 # typed: false
 
-RSpec.describe RuboCop::Cop::Packs::RequireDocumentedPublicApis, :config do
+RSpec.describe RuboCop::Cop::Packs::DocumentedPublicApis, :config do
   # This is the way rubocop itself tests the Style/DocumentationMethod cop
   # https://github.com/rubocop/rubocop/blob/master/spec/rubocop/cop/style/documentation_method_spec.rb
   let(:config) do

--- a/spec/rubocop/cop/packs/root_namespace_is_pack_name_spec.rb
+++ b/spec/rubocop/cop/packs/root_namespace_is_pack_name_spec.rb
@@ -1,7 +1,7 @@
 # typed: false
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::Packs::NamespaceConvention, :config do
+RSpec.describe RuboCop::Cop::Packs::RootNamespaceIsPackName, :config do
   subject(:cop) { described_class.new(config) }
   let(:pack_name) { 'packs/apples' }
 

--- a/spec/rubocop/cop/packs/typed_public_apis_spec.rb
+++ b/spec/rubocop/cop/packs/typed_public_apis_spec.rb
@@ -1,6 +1,6 @@
 # typed: false
 
-RSpec.describe RuboCop::Cop::Packs::TypedPublicApi, :config do
+RSpec.describe RuboCop::Cop::Packs::TypedPublicApis, :config do
   let(:config) do
     RuboCop::Config.new
   end

--- a/spec/rubocop/packs_spec.rb
+++ b/spec/rubocop/packs_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RuboCop::Packs do
   before do
     RuboCop::Packs.bust_cache!
     RuboCop::Packs.configure do |config|
-      config.permitted_pack_level_cops = ['Packs/NamespaceConvention', 'Packs/TypedPublicApi', 'Packs/ClassMethodsAsPublicApis']
+      config.permitted_pack_level_cops = ['Packs/RootNamespaceIsPackName', 'Packs/TypedPublicApi', 'Packs/ClassMethodsAsPublicApis']
     end
   end
 
@@ -13,12 +13,12 @@ RSpec.describe RuboCop::Packs do
 
     before do
       write_package_yml('packs/my_pack')
-      allow(RuboCop::Packs).to receive(:`).with('bundle exec rubocop  --only=Packs/NamespaceConvention,Packs/TypedPublicApi,Packs/ClassMethodsAsPublicApis --format=json').and_return(
+      allow(RuboCop::Packs).to receive(:`).with('bundle exec rubocop  --only=Packs/RootNamespaceIsPackName,Packs/TypedPublicApi,Packs/ClassMethodsAsPublicApis --format=json').and_return(
         {
           'files' => [
             {
               'path' => 'packs/my_pack/path/to/file.rb',
-              'offenses' => [{ 'cop_name' => 'Packs/NamespaceConvention' }, { 'cop_name' => 'Packs/ClassMethodsAsPublicApis' }]
+              'offenses' => [{ 'cop_name' => 'Packs/RootNamespaceIsPackName' }, { 'cop_name' => 'Packs/ClassMethodsAsPublicApis' }]
             }
           ]
         }.to_json
@@ -32,7 +32,7 @@ RSpec.describe RuboCop::Packs do
         expect(rubocop_todo_yml).to exist
         expect(YAML.load_file(rubocop_todo_yml)).to eq(
           {
-            'Packs/NamespaceConvention' => { 'Exclude' => ['packs/my_pack/path/to/file.rb'] },
+            'Packs/RootNamespaceIsPackName' => { 'Exclude' => ['packs/my_pack/path/to/file.rb'] },
             'Packs/ClassMethodsAsPublicApis' => { 'Exclude' => ['packs/my_pack/path/to/file.rb'] }
           }
         )
@@ -44,7 +44,7 @@ RSpec.describe RuboCop::Packs do
         rubocop_todo_yml.write(
           YAML.dump(
             {
-              'Packs/NamespaceConvention' => { 'Exclude' => ['packs/my_pack/path/to/existing_file.rb'] },
+              'Packs/RootNamespaceIsPackName' => { 'Exclude' => ['packs/my_pack/path/to/existing_file.rb'] },
               'Packs/TypedPublicApi' => { 'Exclude' => ['packs/my_pack/path/to/file.rb'] }
             }
           )
@@ -57,7 +57,7 @@ RSpec.describe RuboCop::Packs do
         expect(rubocop_todo_yml).to exist
         expect(YAML.load_file(rubocop_todo_yml)).to eq(
           {
-            'Packs/NamespaceConvention' => { 'Exclude' => ['packs/my_pack/path/to/existing_file.rb', 'packs/my_pack/path/to/file.rb'] },
+            'Packs/RootNamespaceIsPackName' => { 'Exclude' => ['packs/my_pack/path/to/existing_file.rb', 'packs/my_pack/path/to/file.rb'] },
             'Packs/ClassMethodsAsPublicApis' => { 'Exclude' => ['packs/my_pack/path/to/file.rb'] },
             'Packs/TypedPublicApi' => { 'Exclude' => ['packs/my_pack/path/to/file.rb'] }
           }
@@ -85,7 +85,7 @@ RSpec.describe RuboCop::Packs do
         write_package_yml('packs/some_pack')
 
         write_file('packs/some_pack/.rubocop_todo.yml', <<~YML)
-          Packs/NamespaceConvention:
+          Packs/RootNamespaceIsPackName:
             Exclude:
               - 'packs/some_pack/app/services/bad_namespace.rb'
         YML
@@ -94,7 +94,7 @@ RSpec.describe RuboCop::Packs do
       it 'returns the pack\'s exclude' do
         expect(config).to eq(
           {
-            'Packs/NamespaceConvention' => {
+            'Packs/RootNamespaceIsPackName' => {
               'Exclude' => [
                 'packs/some_pack/app/services/bad_namespace.rb'
               ]
@@ -109,7 +109,7 @@ RSpec.describe RuboCop::Packs do
         write_package_yml('packs/some_pack')
 
         write_file('packs/some_pack/.rubocop_todo.yml', <<~YML)
-          Packs/NamespaceConvention:
+          Packs/RootNamespaceIsPackName:
             Exclude:
               - 'packs/some_pack/app/services/bad_namespace.rb'
         YML
@@ -117,16 +117,16 @@ RSpec.describe RuboCop::Packs do
         write_package_yml('packs/some_other_pack')
 
         write_file('packs/some_other_pack/.rubocop_todo.yml', <<~YML)
-          Packs/NamespaceConvention:
+          Packs/RootNamespaceIsPackName:
             Exclude:
               - 'packs/some_other_pack/app/services/bad_namespace.rb'
         YML
       end
 
       it 'returns the pack\'s exclude' do
-        expect(config.keys).to eq(['Packs/NamespaceConvention'])
-        expect(config['Packs/NamespaceConvention'].keys).to eq(['Exclude'])
-        expect(config['Packs/NamespaceConvention']['Exclude'].sort).to eq(['packs/some_other_pack/app/services/bad_namespace.rb', 'packs/some_pack/app/services/bad_namespace.rb'])
+        expect(config.keys).to eq(['Packs/RootNamespaceIsPackName'])
+        expect(config['Packs/RootNamespaceIsPackName'].keys).to eq(['Exclude'])
+        expect(config['Packs/RootNamespaceIsPackName']['Exclude'].sort).to eq(['packs/some_other_pack/app/services/bad_namespace.rb', 'packs/some_pack/app/services/bad_namespace.rb'])
       end
     end
   end
@@ -147,7 +147,7 @@ RSpec.describe RuboCop::Packs do
           write_file('packs/some_pack/app/services/bad_namespace.rb', '')
 
           write_file('packs/some_pack/.rubocop_todo.yml', <<~YML)
-            Packs/NamespaceConvention:
+            Packs/RootNamespaceIsPackName:
               Exclude:
                 - 'packs/some_pack/app/services/bad_namespace.rb'
           YML
@@ -163,7 +163,7 @@ RSpec.describe RuboCop::Packs do
           write_package_yml('packs/some_pack')
 
           write_file('packs/some_pack/.rubocop_todo.yml', <<~YML)
-            Packs/NamespaceConvention:
+            Packs/RootNamespaceIsPackName:
               Exclude:
                 - 'packs/some_pack/app/services/bad_namespace.rb'
           YML
@@ -187,7 +187,7 @@ RSpec.describe RuboCop::Packs do
         it 'returns an error' do
           error = <<~ERROR
             packs/some_pack/.rubocop_todo.yml contains invalid configuration for SomeOtherCop.
-            Please only configure the following cops on a per-pack basis: ["Packs/NamespaceConvention", "Packs/TypedPublicApi", "Packs/ClassMethodsAsPublicApis"]"
+            Please only configure the following cops on a per-pack basis: ["Packs/RootNamespaceIsPackName", "Packs/TypedPublicApi", "Packs/ClassMethodsAsPublicApis"]"
             For ignoring other cops, please instead modify the top-level .rubocop_todo.yml file.
           ERROR
           expect(errors).to eq([error])
@@ -198,7 +198,7 @@ RSpec.describe RuboCop::Packs do
         before do
           write_package_yml('packs/some_pack')
           write_file('packs/some_pack/.rubocop_todo.yml', <<~YML)
-            Packs/NamespaceConvention:
+            Packs/RootNamespaceIsPackName:
               SomethingElse:
                 - 'packs/some_pack/app/services/bad_namespace.rb'
           YML
@@ -206,8 +206,8 @@ RSpec.describe RuboCop::Packs do
 
         it 'returns an error' do
           error = <<~ERROR
-            packs/some_pack/.rubocop_todo.yml contains invalid configuration for Packs/NamespaceConvention.
-            Please ensure the only configuration for Packs/NamespaceConvention is `Exclude`
+            packs/some_pack/.rubocop_todo.yml contains invalid configuration for Packs/RootNamespaceIsPackName.
+            Please ensure the only configuration for Packs/RootNamespaceIsPackName is `Exclude`
           ERROR
           expect(errors).to eq([error])
         end
@@ -220,7 +220,7 @@ RSpec.describe RuboCop::Packs do
           write_package_yml('packs/some_other_pack')
 
           write_file('packs/some_pack/.rubocop_todo.yml', <<~YML)
-            Packs/NamespaceConvention:
+            Packs/RootNamespaceIsPackName:
               Exclude:
                 - 'packs/some_other_pack/app/services/bad_namespace.rb'
           YML
@@ -228,7 +228,7 @@ RSpec.describe RuboCop::Packs do
 
         it 'returns an error' do
           error = <<~ERROR
-            packs/some_pack/.rubocop_todo.yml contains invalid configuration for Packs/NamespaceConvention.
+            packs/some_pack/.rubocop_todo.yml contains invalid configuration for Packs/RootNamespaceIsPackName.
             packs/some_other_pack/app/services/bad_namespace.rb does not belong to packs/some_pack. Please ensure you only add exclusions
             for files within this pack.
           ERROR
@@ -263,7 +263,7 @@ RSpec.describe RuboCop::Packs do
         before do
           write_package_yml('packs/some_pack')
           write_file('packs/some_pack/.rubocop.yml', <<~YML)
-            Packs/NamespaceConvention:
+            Packs/RootNamespaceIsPackName:
               Enabled: true
           YML
         end
@@ -277,7 +277,7 @@ RSpec.describe RuboCop::Packs do
         before do
           write_package_yml('packs/some_pack')
           write_file('packs/some_pack/.rubocop.yml', <<~YML)
-            Packs/NamespaceConvention:
+            Packs/RootNamespaceIsPackName:
               Enabled: true
               FailureMode: strict
           YML
@@ -300,7 +300,7 @@ RSpec.describe RuboCop::Packs do
         it 'returns an error' do
           error = <<~ERROR
             packs/some_pack/.rubocop.yml contains invalid configuration for SomeOtherCop.
-            Please only configure the following cops on a per-pack basis: ["Packs/NamespaceConvention", "Packs/TypedPublicApi", "Packs/ClassMethodsAsPublicApis"]"
+            Please only configure the following cops on a per-pack basis: ["Packs/RootNamespaceIsPackName", "Packs/TypedPublicApi", "Packs/ClassMethodsAsPublicApis"]"
             For ignoring other cops, please instead modify the top-level .rubocop.yml file.
           ERROR
           expect(errors).to eq([error])
@@ -311,7 +311,7 @@ RSpec.describe RuboCop::Packs do
         before do
           write_package_yml('packs/some_pack')
           write_file('packs/some_pack/.rubocop.yml', <<~YML)
-            Packs/NamespaceConvention:
+            Packs/RootNamespaceIsPackName:
               Exclude:
                 - 'packs/some_pack/app/services/bad_namespace.rb'
           YML
@@ -319,8 +319,8 @@ RSpec.describe RuboCop::Packs do
 
         it 'returns an error' do
           error = <<~ERROR
-            packs/some_pack/.rubocop.yml contains invalid configuration for Packs/NamespaceConvention.
-            Please ensure the only configuration for Packs/NamespaceConvention is `Enabled` and `FailureMode`
+            packs/some_pack/.rubocop.yml contains invalid configuration for Packs/RootNamespaceIsPackName.
+            Please ensure the only configuration for Packs/RootNamespaceIsPackName is `Enabled` and `FailureMode`
           ERROR
           expect(errors).to eq([error])
         end
@@ -329,14 +329,14 @@ RSpec.describe RuboCop::Packs do
       context 'one pack with unspecified cops' do
         before do
           RuboCop::Packs.configure do |config|
-            config.required_pack_level_cops = ['Packs/NamespaceConvention', 'Packs/TypedPublicApi']
+            config.required_pack_level_cops = ['Packs/RootNamespaceIsPackName', 'Packs/TypedPublicApi']
           end
         end
 
         before do
           write_package_yml('packs/some_pack')
           write_file('packs/some_pack/.rubocop.yml', <<~YML)
-            Packs/NamespaceConvention:
+            Packs/RootNamespaceIsPackName:
               Enabled: true
           YML
         end
@@ -370,13 +370,13 @@ RSpec.describe RuboCop::Packs do
             write_file('packs/some_pack/app/services/some_file.rb', '')
 
             write_file('packs/some_pack/.rubocop.yml', <<~YML)
-              Packs/NamespaceConvention:
+              Packs/RootNamespaceIsPackName:
                 Enabled: true
                 FailureMode: strict
             YML
 
             write_file('packs/some_pack/.rubocop_todo.yml', <<~YML)
-              Packs/NamespaceConvention:
+              Packs/RootNamespaceIsPackName:
                 Exclude:
                   - 'packs/some_pack/app/services/some_file.rb'
             YML
@@ -384,7 +384,7 @@ RSpec.describe RuboCop::Packs do
 
           it 'returns an empty list' do
             expect(errors).to eq([
-                                   'packs/some_pack has set `Packs/NamespaceConvention` to `FailureMode: strict` in `packs/some_pack/.rubocop.yml`, forbidding new exceptions. Please either remove `packs/some_pack/app/services/some_file.rb` from the top-level and pack-specific `.rubocop_todo.yml` files or remove `FailureMode: strict`.'
+                                   'packs/some_pack has set `Packs/RootNamespaceIsPackName` to `FailureMode: strict` in `packs/some_pack/.rubocop.yml`, forbidding new exceptions. Please either remove `packs/some_pack/app/services/some_file.rb` from the top-level and pack-specific `.rubocop_todo.yml` files or remove `FailureMode: strict`.'
                                  ])
           end
         end
@@ -396,13 +396,13 @@ RSpec.describe RuboCop::Packs do
             write_file('packs/some_pack/app/services/some_file.rb', '')
 
             write_file('packs/some_pack/.rubocop.yml', <<~YML)
-              Packs/NamespaceConvention:
+              Packs/RootNamespaceIsPackName:
                 Enabled: true
                 FailureMode: strict
             YML
 
             write_file('.rubocop_todo.yml', <<~YML)
-              Packs/NamespaceConvention:
+              Packs/RootNamespaceIsPackName:
                 Exclude:
                   - 'packs/some_pack/app/services/some_file.rb'
             YML
@@ -410,7 +410,7 @@ RSpec.describe RuboCop::Packs do
 
           it 'returns an empty list' do
             expect(errors).to eq([
-                                   'packs/some_pack has set `Packs/NamespaceConvention` to `FailureMode: strict` in `packs/some_pack/.rubocop.yml`, forbidding new exceptions. Please either remove `packs/some_pack/app/services/some_file.rb` from the top-level and pack-specific `.rubocop_todo.yml` files or remove `FailureMode: strict`.'
+                                   'packs/some_pack has set `Packs/RootNamespaceIsPackName` to `FailureMode: strict` in `packs/some_pack/.rubocop.yml`, forbidding new exceptions. Please either remove `packs/some_pack/app/services/some_file.rb` from the top-level and pack-specific `.rubocop_todo.yml` files or remove `FailureMode: strict`.'
                                  ])
           end
         end


### PR DESCRIPTION
# Commits
- Improve Packs/ClassMethodsAsPublicApis
- Rename namespace convention
- Rename TypedPublicApis
- Rename DocumentedPublicApis
- Bump version
