### PR TITLE
Specify FailureMode parameter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-packs (0.0.18)
+    rubocop-packs (0.0.19)
       activesupport
       parse_packwerk
       rubocop

--- a/config/default.yml
+++ b/config/default.yml
@@ -7,15 +7,19 @@ Packs/ClassMethodsAsPublicApis:
     - T::Struct
     - Struct
     - OpenStruct
+  FailureMode: default
 
 Packs/RootNamespaceIsPackName:
   Enabled: true
+  FailureMode: default
 
 Packs/TypedPublicApis:
   Enabled: true
+  FailureMode: default
 
 Packs/DocumentedPublicApis:
   Enabled: true
+  FailureMode: default
 
 PackwerkLite/Privacy:
   # It is recommended to use packwerk

--- a/manual/cops_packs.md
+++ b/manual/cops_packs.md
@@ -36,6 +36,7 @@ end
 Name | Default value | Configurable values
 --- | --- | ---
 AcceptableParentClasses | `T::Enum`, `T::Struct`, `Struct`, `OpenStruct` | Array
+FailureMode | `default` | String
 
 ## Packs/DocumentedPublicApis
 
@@ -63,6 +64,12 @@ class Foo
 end
 ```
 
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+FailureMode | `default` | String
+
 ## Packs/RootNamespaceIsPackName
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
@@ -87,6 +94,12 @@ class Blah::Bar; end
 class Foo::Blah::Bar; end
 ```
 
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+FailureMode | `default` | String
+
 ## Packs/TypedPublicApis
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
@@ -108,3 +121,9 @@ module Foo; end
 # typed: strict
 module Foo; end
 ```
+
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+FailureMode | `default` | String

--- a/rubocop-packs.gemspec
+++ b/rubocop-packs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'rubocop-packs'
-  spec.version       = '0.0.18'
+  spec.version       = '0.0.19'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'Fill this out!'


### PR DESCRIPTION
Right now we are getting this message:
```
Warning: Packs/TypedPublicApis does not support FailureMode parameter.
 
Supported parameters are:
 
  - Enabled
```

In order to address this, we need the default cop configuration to specify the parameter so it registers as a valid parameter.
