### PR TITLE
Update pack level rubocop YML with new naming convention

### DIFF
--- a/ADVANCED_USAGE.md
+++ b/ADVANCED_USAGE.md
@@ -1,0 +1,47 @@
+# Advanced Usage
+
+## Pack-Level `package_rubocop.yml` and `package_rubocop_todo.yml` files
+`rubocop-packs` also has some API that help you use rubocop in a pack-based context.
+
+### Basic Configuration
+In your top-level `.rubocop.yml` file, you'll want to include configuration from `rubocop-packs`:
+```yml
+inherit_gem:
+  rubocop-packs:
+    - config/default.yml
+```
+
+This is the mechanism by which pack level rubocop files are incorporated into the top-level config.
+
+### Per-pack `package_rubocop.yml`
+While `rubocop-packs` can be used like any other `rubocop` by configuring in your top-level `.rubocop.yml` file, we also have a number of tools to support per-pack configuration.
+
+To add a per-pack `package_rubocop.yml`, you just need to create a `packs/your_pack/package_rubocop.yml`. With this, each pack can specify an allow-listed set of cops (see below) that can be configured on a per-package level.
+
+### Per-pack `package_rubocop_todo.yml`
+To create a per-pack `package_rubocop_todo.yml`, you can use the following API from `rubocop-packs`:
+```ruby
+RuboCop::Packs.auto_generate_rubocop_todo(packs: ParsePackwerk.all)
+```
+This API will auto-generate a `packs/some_pack/package_rubocop_todo.yml`. This allows a pack to own its own exception list.
+
+### Configuration and Validation
+To use per-pack `package_rubocop.yml` and `package_rubocop_todo.yml` files, you need to configure `rubocop-packs`:
+```ruby
+# config/rubocop_packs.rb
+RuboCop::Packs.configure do |config|
+  config.permitted_pack_level_cops = ['Packs/RootNamespaceIsPackName']
+  config.required_pack_level_cops = ['Packs/RootNamespaceIsPackName']
+end
+```
+
+The above two settings have associated validations that run with `RuboCop::Packs.validate`, which returns an array of errors. We recommend validating this in your test suite, for example:
+```ruby
+RSpec.describe 'rubocop-packs validations' do
+  it { expect(RuboCop::Packs.validate).to be_empty }
+end
+```
+
+Validations include:
+- Ensuring that `packs/*/package_rubocop_todo.yml` files only contain exceptions for the allow-list of `permitted_pack_level_cops`
+- Ensuring that `packs/*/package_rubocop.yml` files contain all of the cops listed in `required_pack_level_cops` and no other cops. This is to ensure that these files are only used to turn on and off an allow-list of cops, as most users would not want packs to configure most `rubocop` rules in a way that is different from the rest of the application.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-packs (0.0.19)
+    rubocop-packs (0.0.20)
       activesupport
       parse_packwerk
       rubocop

--- a/README.md
+++ b/README.md
@@ -41,50 +41,8 @@ Packs/RootNamespaceIsPackName:
     - lib/example.rb
 ```
 
-## Pack-Level `.rubocop.yml` and `.rubocop_todo.yml` files
-`rubocop-packs` also has some API that help you use rubocop in a pack-based context.
-
-### Per-pack `.rubocop.yml`
-While `rubocop-packs` can be used like any other `rubocop` by configuring in your top-level `.rubocop.yml` file, we also have a number of tools to support per-pack configuration.
-
-To add a per-pack `.rubocop.yml`, you just need to create a `packs/your_pack/.rubocop.yml` and then include:
-```yml
-inherit_from: '../../.rubocop.yml'
-```
-
-Note though that inherited paths are relative to your pack-level `.rubocop.yml`. To avoid that, you can rename your `.rubocop.yml` to `.base_rubocop.yml`, set `.rubocop.yml` to:
-```
-inherit_from: '.base_rubocop.yml'
-```
-And then similarly change the `inherit_from` in `packs/your_pack/.rubocop.yml`.
-
-### Per-pack `.rubocop_todo.yml`
-To create a per-pack `.rubocop_todo.yml`, you can use the following API from `rubocop-packs`:
-```ruby
-RuboCop::Packs.auto_generate_rubocop_todo(packs: ParsePackwerk.all)
-```
-This API will auto-generate a `packs/some_pack/.rubocop_todo.yml`. This allows a pack to own its own exception list.
-
-### Configuration and Validation
-To use per-pack `.rubocop.yml` and `.rubocop_todo.yml` files, you need to configure `rubocop-packs`:
-```ruby
-# config/rubocop_packs.rb
-RuboCop::Packs.configure do |config|
-  config.permitted_pack_level_cops = ['Packs/RootNamespaceIsPackName']
-  config.required_pack_level_cops = ['Packs/RootNamespaceIsPackName']
-end
-```
-
-The above two settings have associated validations that run with `RuboCop::Packs.validate`, which returns an array of errors. We recommend validating this in your test suite, for example:
-```ruby
-RSpec.describe 'rubocop-packs validations' do
-  it { expect(RuboCop::Packs.validate).to be_empty }
-end
-```
-
-Validations include:
-- Ensuring that `packs/*/.rubocop_todo.yml` files only contain exceptions for the allow-list of `permitted_pack_level_cops`
-- Ensuring that `packs/*/.rubocop.yml` files contain all of the cops listed in `required_pack_level_cops` and no other cops. This is to ensure that these files are only used to turn on and off an allow-list of cops, as most users would not want packs to configure most `rubocop` rules in a way that is different from the rest of the application.
+## Pack-Level `package_rubocop.yml` and `package_rubocop_todo.yml` files
+See [ADVANCED_USAGE.md](ADVANCED_USAGE.md)
 
 ## Contributing
 

--- a/config/pack_config.yml
+++ b/config/pack_config.yml
@@ -3,4 +3,4 @@
 #    - https://docs.rubocop.org/rubocop/configuration.html#inheriting-configuration-from-a-dependency-gem
 #  - ERB in a .rubocop.yml file
 #    - https://docs.rubocop.org/rubocop/configuration.html#pre-processing
-<%= RuboCop::Packs.pack_based_rubocop_todos %>
+<%= RuboCop::Packs.pack_based_rubocop_config %>

--- a/docs/packwerk_lite.md
+++ b/docs/packwerk_lite.md
@@ -16,7 +16,7 @@ So why would we want to do this...?
 - Experimentally and hypothetically, as a way to provide early feedback loop for engineers who are more familiar with rubocop
 
 What is missing?
-- In order to run this, we need to read from AND write to `deprecated_references.yml` file so that they pick up and ignore the same things (right now we only read from). We'd likely also need to expose a validation to allow the client to confirm that the `**/.rubocop_todo.yml` entries for `PackwerkLite/Privacy` and `PackwerkLite/Dependency` are empty.
+- In order to run this, we need to read from AND write to `deprecated_references.yml` file so that they pick up and ignore the same things (right now we only read from). We'd likely also need to expose a validation to allow the client to confirm that the `**/package_rubocop_todo.yml` entries for `PackwerkLite/Privacy` and `PackwerkLite/Dependency` are empty.
 - There were very few false positives (things this picked up that `packwerk` did not) in Gusto's codebase, but we'd want to address those too.
 
 # Appendix

--- a/lib/rubocop/packs.rb
+++ b/lib/rubocop/packs.rb
@@ -92,7 +92,7 @@ module RuboCop
     sig { params(root_pathname: String).returns(String) }
     # It would be great if rubocop (upstream) could take in a glob for `inherit_from`, which
     # would allow us to delete this method and this additional complexity.
-    def self.pack_based_rubocop_todos(root_pathname: Bundler.root)
+    def self.pack_based_rubocop_config(root_pathname: Bundler.root)
       rubocop_todos = {}
       # We do this because when the ERB is evaluated Dir.pwd is at the directory containing the YML.
       # Ideally rubocop wouldn't change the PWD before invoking this method.

--- a/lib/rubocop/packs.rb
+++ b/lib/rubocop/packs.rb
@@ -74,16 +74,15 @@ module RuboCop
       packs.each do |pack|
         rubocop_yml = Pathname.new(pack.directory.join('.rubocop.yml'))
         rubocop_yml_hash = {}
-        rubocop_yml_hash['inherit_from'] = '../../.base_rubocop.yml'
         config.required_pack_level_cops.each do |cop|
           rubocop_yml_hash[cop] = { 'Enabled' => true }
         end
 
         formatted_yml = YAML.dump(rubocop_yml_hash).
-          # Remove the `---` header at the top of the file
-          gsub("---\n", '').
           # Find lines of the form \nCopDepartment/CopName: and add a new line before it.
-          gsub(%r{^(\w+/\w+:)}, "\n\\1")
+          gsub(%r{^(\w+/\w+:)}, "\n\\1").
+          # Remove the `---` header at the top of the file
+          gsub("---\n\n", '')
 
         rubocop_yml.write(formatted_yml)
       end

--- a/rubocop-packs.gemspec
+++ b/rubocop-packs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'rubocop-packs'
-  spec.version       = '0.0.19'
+  spec.version       = '0.0.20'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'Fill this out!'

--- a/spec/rubocop/packs_spec.rb
+++ b/spec/rubocop/packs_spec.rb
@@ -103,10 +103,10 @@ RSpec.describe RuboCop::Packs do
     end
   end
 
-  describe 'pack_based_rubocop_todos' do
+  describe 'pack_based_rubocop_config' do
     let(:config) do
       write_file('config/default.yml', <<~YML.strip)
-        <%= RuboCop::Packs.pack_based_rubocop_todos(root_pathname: Pathname.pwd.to_s) %>
+        <%= RuboCop::Packs.pack_based_rubocop_config(root_pathname: Pathname.pwd.to_s) %>
       YML
       YAML.safe_load(ERB.new(File.read('config/default.yml')).result(binding))
     end

--- a/spec/rubocop/packs_spec.rb
+++ b/spec/rubocop/packs_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe RuboCop::Packs do
       RuboCop::Packs.set_default_rubocop_yml(packs: ParsePackwerk.all)
       expect(rubocop_yml).to exist
       expect(YAML.load_file(rubocop_yml)).to eq({
-                                                  'inherit_from' => '../../.base_rubocop.yml',
                                                   'Style/SomeCop' => { 'Enabled' => true },
                                                   'Lint/SomeCop' => { 'Enabled' => true }
                                                 })
@@ -34,8 +33,6 @@ RSpec.describe RuboCop::Packs do
       RuboCop::Packs.set_default_rubocop_yml(packs: ParsePackwerk.all)
       expect(rubocop_yml).to exist
       expect(rubocop_yml.read).to eq(<<~YML)
-        inherit_from: "../../.base_rubocop.yml"
-
         Style/SomeCop:
           Enabled: true
 

--- a/spec/rubocop/packs_spec.rb
+++ b/spec/rubocop/packs_spec.rb
@@ -16,9 +16,9 @@ RSpec.describe RuboCop::Packs do
       end
     end
 
-    let(:rubocop_yml) { ParsePackwerk.find('packs/my_pack').directory.join('.rubocop.yml') }
+    let(:rubocop_yml) { ParsePackwerk.find('packs/my_pack').directory.join('package_rubocop.yml') }
 
-    it 'generates a .rubocop.yml with the right required pack level cops' do
+    it 'generates a package_rubocop.yml with the right required pack level cops' do
       expect(rubocop_yml).to_not exist
       RuboCop::Packs.set_default_rubocop_yml(packs: ParsePackwerk.all)
       expect(rubocop_yml).to exist
@@ -28,7 +28,7 @@ RSpec.describe RuboCop::Packs do
                                                 })
     end
 
-    it 'formats the .rubocop.yml file nicely' do
+    it 'formats the package_rubocop.yml file nicely' do
       expect(rubocop_yml).to_not exist
       RuboCop::Packs.set_default_rubocop_yml(packs: ParsePackwerk.all)
       expect(rubocop_yml).to exist
@@ -43,7 +43,7 @@ RSpec.describe RuboCop::Packs do
   end
 
   describe 'auto_generate_rubocop_todo' do
-    let(:rubocop_todo_yml) { Pathname.new('packs/my_pack/.rubocop_todo.yml') }
+    let(:rubocop_todo_yml) { Pathname.new('packs/my_pack/package_rubocop_todo.yml') }
 
     before do
       write_package_yml('packs/my_pack')
@@ -118,7 +118,7 @@ RSpec.describe RuboCop::Packs do
       before do
         write_package_yml('packs/some_pack')
 
-        write_file('packs/some_pack/.rubocop_todo.yml', <<~YML)
+        write_file('packs/some_pack/package_rubocop_todo.yml', <<~YML)
           Packs/RootNamespaceIsPackName:
             Exclude:
               - 'packs/some_pack/app/services/bad_namespace.rb'
@@ -142,7 +142,7 @@ RSpec.describe RuboCop::Packs do
       before do
         write_package_yml('packs/some_pack')
 
-        write_file('packs/some_pack/.rubocop_todo.yml', <<~YML)
+        write_file('packs/some_pack/package_rubocop_todo.yml', <<~YML)
           Packs/RootNamespaceIsPackName:
             Exclude:
               - 'packs/some_pack/app/services/bad_namespace.rb'
@@ -150,7 +150,7 @@ RSpec.describe RuboCop::Packs do
 
         write_package_yml('packs/some_other_pack')
 
-        write_file('packs/some_other_pack/.rubocop_todo.yml', <<~YML)
+        write_file('packs/some_other_pack/package_rubocop_todo.yml', <<~YML)
           Packs/RootNamespaceIsPackName:
             Exclude:
               - 'packs/some_other_pack/app/services/bad_namespace.rb'
@@ -234,7 +234,7 @@ RSpec.describe RuboCop::Packs do
             Enabled: true
         YML
 
-        write_file('packs/some_other_pack/.rubocop_todo.yml', <<~YML)
+        write_file('packs/some_other_pack/package_rubocop_todo.yml', <<~YML)
           Packs/RootNamespaceIsPackName:
             Exclude:
               - packs/some_other_pack/my_file.rb
@@ -247,7 +247,7 @@ RSpec.describe RuboCop::Packs do
             Enabled: true
         YML
 
-        write_file('packs/yet_another_pack/.rubocop_todo.yml', <<~YML)
+        write_file('packs/yet_another_pack/package_rubocop_todo.yml', <<~YML)
           Packs/RootNamespaceIsPackName:
             Exclude:
               - packs/yet_another_pack/my_file.rb
@@ -265,7 +265,7 @@ RSpec.describe RuboCop::Packs do
 
   describe 'validations' do
     let(:errors) { RuboCop::Packs.validate }
-    describe 'pack based .rubocop_todo.yml files' do
+    describe 'pack based package_rubocop_todo.yml files' do
       context 'no packs' do
         it 'returns an empty list' do
           expect(errors).to be_empty
@@ -278,7 +278,7 @@ RSpec.describe RuboCop::Packs do
 
           write_file('packs/some_pack/app/services/bad_namespace.rb', '')
 
-          write_file('packs/some_pack/.rubocop_todo.yml', <<~YML)
+          write_file('packs/some_pack/package_rubocop_todo.yml', <<~YML)
             Packs/RootNamespaceIsPackName:
               Exclude:
                 - 'packs/some_pack/app/services/bad_namespace.rb'
@@ -294,7 +294,7 @@ RSpec.describe RuboCop::Packs do
         before do
           write_package_yml('packs/some_pack')
 
-          write_file('packs/some_pack/.rubocop_todo.yml', <<~YML)
+          write_file('packs/some_pack/package_rubocop_todo.yml', <<~YML)
             Packs/RootNamespaceIsPackName:
               Exclude:
                 - 'packs/some_pack/app/services/bad_namespace.rb'
@@ -309,7 +309,7 @@ RSpec.describe RuboCop::Packs do
       context 'one pack with disallowed cop key' do
         before do
           write_package_yml('packs/some_pack')
-          write_file('packs/some_pack/.rubocop_todo.yml', <<~YML)
+          write_file('packs/some_pack/package_rubocop_todo.yml', <<~YML)
             SomeOtherCop:
               Exclude:
                 - 'packs/some_pack/app/services/bad_namespace.rb'
@@ -318,9 +318,9 @@ RSpec.describe RuboCop::Packs do
 
         it 'returns an error' do
           error = <<~ERROR
-            packs/some_pack/.rubocop_todo.yml contains invalid configuration for SomeOtherCop.
+            packs/some_pack/package_rubocop_todo.yml contains invalid configuration for SomeOtherCop.
             Please only configure the following cops on a per-pack basis: ["Packs/RootNamespaceIsPackName", "Packs/TypedPublicApi", "Packs/ClassMethodsAsPublicApis"]"
-            For ignoring other cops, please instead modify the top-level .rubocop_todo.yml file.
+            For ignoring other cops, please instead modify the top-level package_rubocop_todo.yml file.
           ERROR
           expect(errors).to eq([error])
         end
@@ -329,7 +329,7 @@ RSpec.describe RuboCop::Packs do
       context 'one pack with disallowed configuration key' do
         before do
           write_package_yml('packs/some_pack')
-          write_file('packs/some_pack/.rubocop_todo.yml', <<~YML)
+          write_file('packs/some_pack/package_rubocop_todo.yml', <<~YML)
             Packs/RootNamespaceIsPackName:
               SomethingElse:
                 - 'packs/some_pack/app/services/bad_namespace.rb'
@@ -338,7 +338,7 @@ RSpec.describe RuboCop::Packs do
 
         it 'returns an error' do
           error = <<~ERROR
-            packs/some_pack/.rubocop_todo.yml contains invalid configuration for Packs/RootNamespaceIsPackName.
+            packs/some_pack/package_rubocop_todo.yml contains invalid configuration for Packs/RootNamespaceIsPackName.
             Please ensure the only configuration for Packs/RootNamespaceIsPackName is `Exclude`
           ERROR
           expect(errors).to eq([error])
@@ -351,7 +351,7 @@ RSpec.describe RuboCop::Packs do
 
           write_package_yml('packs/some_other_pack')
 
-          write_file('packs/some_pack/.rubocop_todo.yml', <<~YML)
+          write_file('packs/some_pack/package_rubocop_todo.yml', <<~YML)
             Packs/RootNamespaceIsPackName:
               Exclude:
                 - 'packs/some_other_pack/app/services/bad_namespace.rb'
@@ -360,7 +360,7 @@ RSpec.describe RuboCop::Packs do
 
         it 'returns an error' do
           error = <<~ERROR
-            packs/some_pack/.rubocop_todo.yml contains invalid configuration for Packs/RootNamespaceIsPackName.
+            packs/some_pack/package_rubocop_todo.yml contains invalid configuration for Packs/RootNamespaceIsPackName.
             packs/some_other_pack/app/services/bad_namespace.rb does not belong to packs/some_pack. Please ensure you only add exclusions
             for files within this pack.
           ERROR
@@ -373,28 +373,34 @@ RSpec.describe RuboCop::Packs do
         before do
           write_package_yml('packs/some_pack')
 
-          write_file('packs/some_pack/.rubocop.yml', <<~YML)
-            inherit_from: "../../.base_rubocop.yml"
+          write_file('packs/some_pack/package_rubocop.yml', <<~YML)
+            inherit_from: "something_else.yml"
           YML
         end
 
-        it 'has no errors' do
-          expect(errors).to be_empty
+        it 'has an error' do
+          error = <<~ERROR
+            packs/some_pack/package_rubocop.yml contains invalid configuration for inherit_from.
+            Please only configure the following cops on a per-pack basis: ["Packs/RootNamespaceIsPackName", "Packs/TypedPublicApi", "Packs/ClassMethodsAsPublicApis"]"
+            For ignoring other cops, please instead modify the top-level .rubocop.yml file.
+          ERROR
+
+          expect(errors).to eq([error])
         end
       end
     end
 
-    describe 'pack based .rubocop.yml files' do
+    describe 'pack based package_rubocop.yml files' do
       context 'no packs' do
         it 'returns an empty list' do
           expect(errors).to be_empty
         end
       end
 
-      context 'one pack with valid .rubocop.yml' do
+      context 'one pack with valid package_rubocop.yml' do
         before do
           write_package_yml('packs/some_pack')
-          write_file('packs/some_pack/.rubocop.yml', <<~YML)
+          write_file('packs/some_pack/package_rubocop.yml', <<~YML)
             Packs/RootNamespaceIsPackName:
               Enabled: true
           YML
@@ -405,10 +411,10 @@ RSpec.describe RuboCop::Packs do
         end
       end
 
-      context 'one pack with valid .rubocop.yml with FailureMode specified' do
+      context 'one pack with valid package_rubocop.yml with FailureMode specified' do
         before do
           write_package_yml('packs/some_pack')
-          write_file('packs/some_pack/.rubocop.yml', <<~YML)
+          write_file('packs/some_pack/package_rubocop.yml', <<~YML)
             Packs/RootNamespaceIsPackName:
               Enabled: true
               FailureMode: strict
@@ -423,7 +429,7 @@ RSpec.describe RuboCop::Packs do
       context 'one pack with disallowed cop key' do
         before do
           write_package_yml('packs/some_pack')
-          write_file('packs/some_pack/.rubocop.yml', <<~YML)
+          write_file('packs/some_pack/package_rubocop.yml', <<~YML)
             SomeOtherCop:
               Enabled: true
           YML
@@ -431,7 +437,7 @@ RSpec.describe RuboCop::Packs do
 
         it 'returns an error' do
           error = <<~ERROR
-            packs/some_pack/.rubocop.yml contains invalid configuration for SomeOtherCop.
+            packs/some_pack/package_rubocop.yml contains invalid configuration for SomeOtherCop.
             Please only configure the following cops on a per-pack basis: ["Packs/RootNamespaceIsPackName", "Packs/TypedPublicApi", "Packs/ClassMethodsAsPublicApis"]"
             For ignoring other cops, please instead modify the top-level .rubocop.yml file.
           ERROR
@@ -442,7 +448,7 @@ RSpec.describe RuboCop::Packs do
       context 'one pack with disallowed configuration key' do
         before do
           write_package_yml('packs/some_pack')
-          write_file('packs/some_pack/.rubocop.yml', <<~YML)
+          write_file('packs/some_pack/package_rubocop.yml', <<~YML)
             Packs/RootNamespaceIsPackName:
               Exclude:
                 - 'packs/some_pack/app/services/bad_namespace.rb'
@@ -451,7 +457,7 @@ RSpec.describe RuboCop::Packs do
 
         it 'returns an error' do
           error = <<~ERROR
-            packs/some_pack/.rubocop.yml contains invalid configuration for Packs/RootNamespaceIsPackName.
+            packs/some_pack/package_rubocop.yml contains invalid configuration for Packs/RootNamespaceIsPackName.
             Please ensure the only configuration for Packs/RootNamespaceIsPackName is `Enabled` and `FailureMode`
           ERROR
           expect(errors).to eq([error])
@@ -467,7 +473,7 @@ RSpec.describe RuboCop::Packs do
 
         before do
           write_package_yml('packs/some_pack')
-          write_file('packs/some_pack/.rubocop.yml', <<~YML)
+          write_file('packs/some_pack/package_rubocop.yml', <<~YML)
             Packs/RootNamespaceIsPackName:
               Enabled: true
           YML
@@ -475,14 +481,14 @@ RSpec.describe RuboCop::Packs do
 
         it 'returns an error' do
           error = <<~ERROR
-            packs/some_pack/.rubocop.yml is missing configuration for Packs/TypedPublicApi.
+            packs/some_pack/package_rubocop.yml is missing configuration for Packs/TypedPublicApi.
           ERROR
           expect(errors).to eq([error])
         end
       end
 
       # For now, this is allowed. We might add this restriction back once we've completed the migration off of `package_protections`
-      context 'one pack without a .rubocop.yml' do
+      context 'one pack without a package_rubocop.yml' do
         before do
           write_package_yml('packs/some_pack')
         end
@@ -495,19 +501,19 @@ RSpec.describe RuboCop::Packs do
 
     describe 'FailureMode: strict' do
       context 'package has specified FailureMode: strict for a cop' do
-        context 'package has pack-based .rubocop_todo.yml entries for that cop' do
+        context 'package has pack-based package_rubocop_todo.yml entries for that cop' do
           before do
             write_package_yml('packs/some_pack')
 
             write_file('packs/some_pack/app/services/some_file.rb', '')
 
-            write_file('packs/some_pack/.rubocop.yml', <<~YML)
+            write_file('packs/some_pack/package_rubocop.yml', <<~YML)
               Packs/RootNamespaceIsPackName:
                 Enabled: true
                 FailureMode: strict
             YML
 
-            write_file('packs/some_pack/.rubocop_todo.yml', <<~YML)
+            write_file('packs/some_pack/package_rubocop_todo.yml', <<~YML)
               Packs/RootNamespaceIsPackName:
                 Exclude:
                   - 'packs/some_pack/app/services/some_file.rb'
@@ -516,24 +522,24 @@ RSpec.describe RuboCop::Packs do
 
           it 'returns an empty list' do
             expect(errors).to eq([
-                                   'packs/some_pack has set `Packs/RootNamespaceIsPackName` to `FailureMode: strict` in `packs/some_pack/.rubocop.yml`, forbidding new exceptions. Please either remove `packs/some_pack/app/services/some_file.rb` from the top-level and pack-specific `.rubocop_todo.yml` files or remove `FailureMode: strict`.'
+                                   'packs/some_pack has set `Packs/RootNamespaceIsPackName` to `FailureMode: strict` in `packs/some_pack/package_rubocop.yml`, forbidding new exceptions. Please either remove `packs/some_pack/app/services/some_file.rb` from the top-level and pack-specific `package_rubocop_todo.yml` files or remove `FailureMode: strict`.'
                                  ])
           end
         end
 
-        context 'package has top-level .rubocop_todo.yml entries for that cop' do
+        context 'package has top-level package_rubocop_todo.yml entries for that cop' do
           before do
             write_package_yml('packs/some_pack')
 
             write_file('packs/some_pack/app/services/some_file.rb', '')
 
-            write_file('packs/some_pack/.rubocop.yml', <<~YML)
+            write_file('packs/some_pack/package_rubocop.yml', <<~YML)
               Packs/RootNamespaceIsPackName:
                 Enabled: true
                 FailureMode: strict
             YML
 
-            write_file('.rubocop_todo.yml', <<~YML)
+            write_file('package_rubocop_todo.yml', <<~YML)
               Packs/RootNamespaceIsPackName:
                 Exclude:
                   - 'packs/some_pack/app/services/some_file.rb'
@@ -542,7 +548,7 @@ RSpec.describe RuboCop::Packs do
 
           it 'returns an empty list' do
             expect(errors).to eq([
-                                   'packs/some_pack has set `Packs/RootNamespaceIsPackName` to `FailureMode: strict` in `packs/some_pack/.rubocop.yml`, forbidding new exceptions. Please either remove `packs/some_pack/app/services/some_file.rb` from the top-level and pack-specific `.rubocop_todo.yml` files or remove `FailureMode: strict`.'
+                                   'packs/some_pack has set `Packs/RootNamespaceIsPackName` to `FailureMode: strict` in `packs/some_pack/package_rubocop.yml`, forbidding new exceptions. Please either remove `packs/some_pack/app/services/some_file.rb` from the top-level and pack-specific `package_rubocop_todo.yml` files or remove `FailureMode: strict`.'
                                  ])
           end
         end


### PR DESCRIPTION
The idea behind this PR is to allow pack-level rubocop YML files to work as expected. Previously, we were experimenting with pack-level `.rubocop_todo.yml` and pack-level `.rubocop.yml` files. It turned out that pack-level `.rubocop.yml` files were rather painful because they created tons of path relativity issues, which we anticipated would create lots of maintenance challenges.

Therefore we moved to pack-level `package_rubocop.yml` files, which semantically match packwerk `package_todo.yml` files and are more clearly pulled into rubocop execution by something other than rubocop itself.

We also renamed `.rubocop_todo.yml` to `package_rubocop_todo.yml` for consistency.

As part of this, I moved the pack-level rubocop information from the README into "advanced usage" because it's not necessary to get value from `rubocop-packs` and I think at a lot of orgs it would be more valuable to just use the cops in this repo in a more vanilla way, so we want to continue to support that.

# Commits
- Rename method to pack_based_rubocop_config
- Include pack level rubocop files in top-level rubocop config via ERB
- Move per-pack rubocop stuff into advanced usage
- Update tests for set_default_rubocop_yml
- Fix failed test for set_default_rubocop_yml
- Change tests to account for new naming convention
- Fix tests for package level rubocop YML files
- Bump version
