### PR TITLE
Set cop default values to disabled

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-packs (0.0.21)
+    rubocop-packs (0.0.22)
       activesupport
       parse_packwerk
       rubocop

--- a/config/default.yml
+++ b/config/default.yml
@@ -8,15 +8,15 @@ Packs/ClassMethodsAsPublicApis:
   FailureMode: default
 
 Packs/RootNamespaceIsPackName:
-  Enabled: true
+  Enabled: false
   FailureMode: default
 
 Packs/TypedPublicApis:
-  Enabled: true
+  Enabled: false
   FailureMode: default
 
 Packs/DocumentedPublicApis:
-  Enabled: true
+  Enabled: false
   FailureMode: default
 
 PackwerkLite/Privacy:

--- a/manual/cops_packs.md
+++ b/manual/cops_packs.md
@@ -42,7 +42,7 @@ FailureMode | `default` | String
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | No | - | -
+Disabled | Yes | No | - | -
 
 This cop helps ensure that each pack has a documented public API
 The following examples assume this basic setup.
@@ -74,7 +74,7 @@ FailureMode | `default` | String
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | No | - | -
+Disabled | Yes | No | - | -
 
 This cop helps ensure that each pack exposes one namespace.
 Note that this cop doesn't necessarily expect you to be using stimpack (https://github.com/rubyatscale/stimpack),
@@ -104,7 +104,7 @@ FailureMode | `default` | String
 
 Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
 --- | --- | --- | --- | ---
-Enabled | Yes | Yes  | - | -
+Disabled | Yes | Yes  | - | -
 
 This cop helps ensure that each pack's public API is strictly typed, enforcing strong boundaries.
 

--- a/rubocop-packs.gemspec
+++ b/rubocop-packs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'rubocop-packs'
-  spec.version       = '0.0.21'
+  spec.version       = '0.0.22'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'Fill this out!'


### PR DESCRIPTION
The idea here is that Gusto uses pack specific rubocop.yml files, and those files are what enable these cops on a per-pack basis.

However, we don't want these pack specific cops to be active for the root pack, so I think the easiest thing to do is to turn these *off* for now and allow the client to explicitly turn them on (and for specific packs/folders) when/where they want them
