### PR TITLE
Support single files being added to package_rubocop_todo.yml files without deleting the old file

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-packs (0.0.24)
+    rubocop-packs (0.0.25)
       activesupport
       parse_packwerk
       rubocop

--- a/lib/rubocop/packs.rb
+++ b/lib/rubocop/packs.rb
@@ -5,6 +5,8 @@ require 'rubocop/packs/private'
 
 module RuboCop
   module Packs
+    extend T::Sig
+
     # Pack-level rubocop and rubocop_todo YML files are named differently because they are not integrated
     # into rubocop in the standard way. For example, we could call these the standard `.rubocop.yml` and
     # `.rubocop_todo.yml`. However, this introduces a number of path relativity issues (https://docs.rubocop.org/rubocop/configuration.html#path-relativity)
@@ -13,9 +15,6 @@ module RuboCop
     PACK_LEVEL_RUBOCOP_YML = 'package_rubocop.yml'
     PACK_LEVEL_RUBOCOP_TODO_YML = 'package_rubocop_todo.yml'
 
-    extend T::Sig
-
-    # Your code goes here...
     PROJECT_ROOT   = T.let(Pathname.new(__dir__).parent.parent.expand_path.freeze, Pathname)
     CONFIG_DEFAULT = T.let(PROJECT_ROOT.join('config', 'default.yml').freeze, Pathname)
     CONFIG         = T.let(YAML.safe_load(CONFIG_DEFAULT.read).freeze, T.untyped)

--- a/lib/rubocop/packs.rb
+++ b/lib/rubocop/packs.rb
@@ -36,6 +36,7 @@ module RuboCop
 
       offenses.group_by(&:pack).each do |pack, offenses_for_pack|
         next if pack.name == ParsePackwerk::ROOT_PACKAGE_NAME
+        next if !pack.directory.join(PACK_LEVEL_RUBOCOP_YML).exist?
 
         rubocop_todo_yml = pack.directory.join(PACK_LEVEL_RUBOCOP_TODO_YML)
         # If the user is passing in packs, then regenerate from scratch.

--- a/lib/rubocop/packs.rb
+++ b/lib/rubocop/packs.rb
@@ -13,7 +13,6 @@ module RuboCop
     PACK_LEVEL_RUBOCOP_YML = 'package_rubocop.yml'
     PACK_LEVEL_RUBOCOP_TODO_YML = 'package_rubocop_todo.yml'
 
-    class Error < StandardError; end
     extend T::Sig
 
     # Your code goes here...

--- a/lib/rubocop/packs/private.rb
+++ b/lib/rubocop/packs/private.rb
@@ -155,28 +155,27 @@ module RuboCop
         end
       end
 
-
-    sig { params(paths: T::Array[String], cop_names: T::Array[String]).returns(T::Array[Offense]) }
-    def self.offenses_for(paths:, cop_names:)
-      path_arguments = paths.join(' ')
-      cop_arguments = cop_names.join(',')
-      # I think we can potentially use `RuboCop::CLI.new(args)` for this to avoid shelling out and starting another process that needs to reload the bundle
-      args = [path_arguments, "--only=#{cop_arguments}", '--format=json']
-      puts "Executing: bundle exec rubocop #{args.join(' ')}"
-      json = JSON.parse(Private.execute_rubocop(args))
-      offenses = T.let([], T::Array[Offense])
-      json['files'].each do |file_hash|
-        filepath = file_hash['path']
-        file_hash['offenses'].each do |offense_hash|
-          offenses << Offense.new(
-            cop_name: offense_hash['cop_name'],
-            filepath: filepath
-          )
+      sig { params(paths: T::Array[String], cop_names: T::Array[String]).returns(T::Array[Offense]) }
+      def self.offenses_for(paths:, cop_names:)
+        path_arguments = paths.join(' ')
+        cop_arguments = cop_names.join(',')
+        # I think we can potentially use `RuboCop::CLI.new(args)` for this to avoid shelling out and starting another process that needs to reload the bundle
+        args = [path_arguments, "--only=#{cop_arguments}", '--format=json']
+        puts "Executing: bundle exec rubocop #{args.join(' ')}"
+        json = JSON.parse(Private.execute_rubocop(args))
+        offenses = T.let([], T::Array[Offense])
+        json['files'].each do |file_hash|
+          filepath = file_hash['path']
+          file_hash['offenses'].each do |offense_hash|
+            offenses << Offense.new(
+              cop_name: offense_hash['cop_name'],
+              filepath: filepath
+            )
+          end
         end
-      end
 
-      offenses
-    end
+        offenses
+      end
 
       sig { params(block: T.untyped).returns(String) }
       def self.with_captured_stdout(&block)

--- a/lib/rubocop/packs/private.rb
+++ b/lib/rubocop/packs/private.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require 'rubocop/packs/private/configuration'
+require 'rubocop/packs/private/offense'
 
 module RuboCop
   module Packs
@@ -153,6 +154,29 @@ module RuboCop
           RuboCop::CLI.new.run(args)
         end
       end
+
+
+    sig { params(paths: T::Array[String], cop_names: T::Array[String]).returns(T::Array[Offense]) }
+    def self.offenses_for(paths:, cop_names:)
+      path_arguments = paths.join(' ')
+      cop_arguments = cop_names.join(',')
+      # I think we can potentially use `RuboCop::CLI.new(args)` for this to avoid shelling out and starting another process that needs to reload the bundle
+      args = [path_arguments, "--only=#{cop_arguments}", '--format=json']
+      puts "Executing: bundle exec rubocop #{args.join(' ')}"
+      json = JSON.parse(Private.execute_rubocop(args))
+      offenses = T.let([], T::Array[Offense])
+      json['files'].each do |file_hash|
+        filepath = file_hash['path']
+        file_hash['offenses'].each do |offense_hash|
+          offenses << Offense.new(
+            cop_name: offense_hash['cop_name'],
+            filepath: filepath
+          )
+        end
+      end
+
+      offenses
+    end
 
       sig { params(block: T.untyped).returns(String) }
       def self.with_captured_stdout(&block)

--- a/lib/rubocop/packs/private/offense.rb
+++ b/lib/rubocop/packs/private/offense.rb
@@ -1,0 +1,19 @@
+# typed: strict
+
+module RuboCop
+  module Packs
+    module Private
+      class Offense < T::Struct
+        extend T::Sig
+
+        const :cop_name, String
+        const :filepath, String
+
+        sig { returns(ParsePackwerk::Package) }
+        def pack
+          ParsePackwerk.package_from_path(filepath)
+        end
+      end
+    end
+  end
+end

--- a/rubocop-packs.gemspec
+++ b/rubocop-packs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'rubocop-packs'
-  spec.version       = '0.0.24'
+  spec.version       = '0.0.25'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'Fill this out!'

--- a/spec/rubocop/packs_spec.rb
+++ b/spec/rubocop/packs_spec.rb
@@ -66,6 +66,8 @@ RSpec.describe RuboCop::Packs do
 
     context 'regenerating TODO for entire packs' do
       context 'pack has no current rubocop todo' do
+        before { write_file('packs/my_pack/package_rubocop.yml') }
+
         it 'creates the TODO' do
           expect(rubocop_todo_yml).to_not exist
           RuboCop::Packs.regenerate_todo(packs: [ParsePackwerk.find('packs/my_pack')])
@@ -79,8 +81,17 @@ RSpec.describe RuboCop::Packs do
         end
       end
 
+      context 'pack does not use pack-based rubocop' do
+        it 'does not create the TODO' do
+          expect(rubocop_todo_yml).to_not exist
+          RuboCop::Packs.regenerate_todo(packs: [ParsePackwerk.find('packs/my_pack')])
+          expect(rubocop_todo_yml).to_not exist
+        end
+      end
+
       context 'pack has an existing rubocop todo' do
         before do
+          write_file('packs/my_pack/package_rubocop.yml')
           rubocop_todo_yml.write(
             YAML.dump(
               {
@@ -107,6 +118,8 @@ RSpec.describe RuboCop::Packs do
 
     context 'regenerating TODO for files' do
       context 'pack has no current rubocop todo' do
+        before { write_file('packs/my_pack/package_rubocop.yml') }
+
         it 'creates the TODO' do
           expect(rubocop_todo_yml).to_not exist
           RuboCop::Packs.regenerate_todo(files: ['packs/my_pack/path/to/file.rb'])
@@ -120,6 +133,14 @@ RSpec.describe RuboCop::Packs do
         end
       end
 
+      context 'pack does not use pack-based rubocop' do
+        it 'does not create the TODO' do
+          expect(rubocop_todo_yml).to_not exist
+          RuboCop::Packs.regenerate_todo(files: ['packs/my_pack/path/to/file.rb'])
+          expect(rubocop_todo_yml).to_not exist
+        end
+      end
+
       context 'pack has an existing rubocop todo' do
         before do
           rubocop_todo_yml.write(
@@ -130,6 +151,7 @@ RSpec.describe RuboCop::Packs do
               }
             )
           )
+          write_file('packs/my_pack/package_rubocop.yml')
         end
 
         it 'adds to the TODO with the new files' do


### PR DESCRIPTION
- Remove an unused class
- Move up extend T::Sig
- Allow regenerate_todo to augment existing YML files with individual file offenses
- move things to private
