### PR TITLE
Fix bug when calling rubocop with multiple files

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-packs (0.0.25)
+    rubocop-packs (0.0.26)
       activesupport
       parse_packwerk
       rubocop

--- a/lib/rubocop/packs/private.rb
+++ b/lib/rubocop/packs/private.rb
@@ -157,10 +157,9 @@ module RuboCop
 
       sig { params(paths: T::Array[String], cop_names: T::Array[String]).returns(T::Array[Offense]) }
       def self.offenses_for(paths:, cop_names:)
-        path_arguments = paths.join(' ')
         cop_arguments = cop_names.join(',')
         # I think we can potentially use `RuboCop::CLI.new(args)` for this to avoid shelling out and starting another process that needs to reload the bundle
-        args = [path_arguments, "--only=#{cop_arguments}", '--format=json']
+        args = [*paths, "--only=#{cop_arguments}", '--format=json']
         puts "Executing: bundle exec rubocop #{args.join(' ')}"
         json = JSON.parse(Private.execute_rubocop(args))
         offenses = T.let([], T::Array[Offense])

--- a/rubocop-packs.gemspec
+++ b/rubocop-packs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'rubocop-packs'
-  spec.version       = '0.0.25'
+  spec.version       = '0.0.26'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'Fill this out!'


### PR DESCRIPTION
Rubocop should receive the different paths as individual elements in the args array
