### PR TITLE
Properly delete pack-level rubocop TODOs when regenerating TODO

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-packs (0.0.26)
+    rubocop-packs (0.0.27)
       activesupport
       parse_packwerk
       rubocop

--- a/lib/rubocop/packs.rb
+++ b/lib/rubocop/packs.rb
@@ -28,6 +28,12 @@ module RuboCop
     #
     sig { params(packs: T::Array[ParsePackwerk::Package], files: T::Array[String]).void }
     def self.regenerate_todo(packs: [], files: [])
+      # Delete the old pack-level rubocop todo files so that we can regenerate the new one from scratch
+      packs.each do |pack|
+        rubocop_todo_yml = pack.directory.join(PACK_LEVEL_RUBOCOP_TODO_YML)
+        rubocop_todo_yml.delete if rubocop_todo_yml.exist?
+      end
+
       paths = packs.empty? ? files : packs.map(&:name).reject { |name| name == ParsePackwerk::ROOT_PACKAGE_NAME }
       offenses = Private.offenses_for(
         paths: paths,
@@ -39,11 +45,7 @@ module RuboCop
         next if !pack.directory.join(PACK_LEVEL_RUBOCOP_YML).exist?
 
         rubocop_todo_yml = pack.directory.join(PACK_LEVEL_RUBOCOP_TODO_YML)
-        # If the user is passing in packs, then regenerate from scratch.
-        if packs.any? && rubocop_todo_yml.exist?
-          rubocop_todo_yml.delete
-          rubocop_todo = {}
-        elsif rubocop_todo_yml.exist?
+        if rubocop_todo_yml.exist?
           rubocop_todo = YAML.load_file(rubocop_todo_yml)
         else
           rubocop_todo = {}

--- a/rubocop-packs.gemspec
+++ b/rubocop-packs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'rubocop-packs'
-  spec.version       = '0.0.26'
+  spec.version       = '0.0.27'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'Fill this out!'

--- a/spec/rubocop/packs_spec.rb
+++ b/spec/rubocop/packs_spec.rb
@@ -55,12 +55,12 @@ RSpec.describe RuboCop::Packs do
           }
         ]
       }.to_json
-      allow_any_instance_of(RuboCop::CLI).to receive(:run).with(['packs/my_pack', '--only=Packs/RootNamespaceIsPackName,Packs/TypedPublicApis,Packs/ClassMethodsAsPublicApis', '--format=json']) do
-        puts rubocop_json
+      allow_any_instance_of(RuboCop::CLI).to receive(:run).with(['packs/my_pack', '--only=Packs/RootNamespaceIsPackName,Packs/TypedPublicApis,Packs/ClassMethodsAsPublicApis', '--format=json', '--out=tmp/rubocop-output']) do
+        Pathname.new('tmp/rubocop-output').write(rubocop_json)
       end
 
-      allow_any_instance_of(RuboCop::CLI).to receive(:run).with(['packs/my_pack/path/to/file.rb', '--only=Packs/RootNamespaceIsPackName,Packs/TypedPublicApis,Packs/ClassMethodsAsPublicApis', '--format=json']) do
-        puts rubocop_json
+      allow_any_instance_of(RuboCop::CLI).to receive(:run).with(['packs/my_pack/path/to/file.rb', '--only=Packs/RootNamespaceIsPackName,Packs/TypedPublicApis,Packs/ClassMethodsAsPublicApis', '--format=json', '--out=tmp/rubocop-output']) do
+        Pathname.new('tmp/rubocop-output').write(rubocop_json)
       end
     end
 
@@ -180,8 +180,8 @@ RSpec.describe RuboCop::Packs do
           ]
         }.to_json
 
-        allow_any_instance_of(RuboCop::CLI).to receive(:run).with(['packs/my_pack/path/to/file.rb', 'packs/my_pack/path/to/other_file.rb', '--only=Packs/RootNamespaceIsPackName,Packs/TypedPublicApis,Packs/ClassMethodsAsPublicApis', '--format=json']) do
-          puts rubocop_json
+        allow_any_instance_of(RuboCop::CLI).to receive(:run).with(['packs/my_pack/path/to/file.rb', 'packs/my_pack/path/to/other_file.rb', '--only=Packs/RootNamespaceIsPackName,Packs/TypedPublicApis,Packs/ClassMethodsAsPublicApis', '--format=json', '--out=tmp/rubocop-output']) do
+          Pathname.new('tmp/rubocop-output').write(rubocop_json)
         end
       end
 


### PR DESCRIPTION
Before, we were deleting the old TODO too late.

We need to delete the old TODO before we run rubocop so rubocop can properly get all of the offenses for that pack
