### PR TITLE
Allow sorbet interfaces to work with Packs/ClassMethodsAsPublicApis

### DIFF
--- a/lib/rubocop/cop/packs/class_methods_as_public_apis.rb
+++ b/lib/rubocop/cop/packs/class_methods_as_public_apis.rb
@@ -52,6 +52,9 @@ module RuboCop
           class_is_allowed_to_have_instance_methods = acceptable_parent_classes.include?(parent_class&.const_name)
           return if uses_implicit_static_methods || class_is_allowed_to_have_instance_methods
 
+          is_interface = !module_node.nil? && module_node.descendants.any?{|d| d.is_a?(RuboCop::AST::SendNode) && d.method_name == :interface! }
+          return if is_interface
+
           add_offense(
             node.source_range,
             message: format(

--- a/lib/rubocop/cop/packs/class_methods_as_public_apis.rb
+++ b/lib/rubocop/cop/packs/class_methods_as_public_apis.rb
@@ -52,8 +52,8 @@ module RuboCop
           class_is_allowed_to_have_instance_methods = acceptable_parent_classes.include?(parent_class&.const_name)
           return if uses_implicit_static_methods || class_is_allowed_to_have_instance_methods
 
-          is_interface = !module_node.nil? && module_node.descendants.any?{|d| d.is_a?(RuboCop::AST::SendNode) && d.method_name == :interface! }
-          return if is_interface
+          is_sorbet_interface_or_abstract_class = !module_node.nil? && module_node.descendants.any?{|d| d.is_a?(RuboCop::AST::SendNode) && (d.method_name == :interface! || d.method_name == :abstract!) }
+          return if is_sorbet_interface_or_abstract_class
 
           add_offense(
             node.source_range,

--- a/lib/rubocop/cop/packs/class_methods_as_public_apis.rb
+++ b/lib/rubocop/cop/packs/class_methods_as_public_apis.rb
@@ -52,7 +52,7 @@ module RuboCop
           class_is_allowed_to_have_instance_methods = acceptable_parent_classes.include?(parent_class&.const_name)
           return if uses_implicit_static_methods || class_is_allowed_to_have_instance_methods
 
-          is_sorbet_interface_or_abstract_class = !module_node.nil? && module_node.descendants.any?{|d| d.is_a?(RuboCop::AST::SendNode) && (d.method_name == :interface! || d.method_name == :abstract!) }
+          is_sorbet_interface_or_abstract_class = !module_node.nil? && module_node.descendants.any? { |d| d.is_a?(RuboCop::AST::SendNode) && (d.method_name == :interface! || d.method_name == :abstract!) }
           return if is_sorbet_interface_or_abstract_class
 
           add_offense(

--- a/spec/rubocop/cop/packs/class_methods_as_public_apis_spec.rb
+++ b/spec/rubocop/cop/packs/class_methods_as_public_apis_spec.rb
@@ -189,4 +189,23 @@ RSpec.describe RuboCop::Cop::Packs::ClassMethodsAsPublicApis, :config do
 
     it { expect_no_offenses source, Pathname.pwd.join('packs/tool/app/public/tool.rb').to_s }
   end
+
+  context 'when module is a sorbet abstract class' do
+    let(:source) do
+      <<~RUBY
+        module Tool
+          extend T::Sig
+          extend T::Helpers
+
+          abstract!
+
+          sig { abstract.void }
+          def my_instance_method
+          end
+        end
+      RUBY
+    end
+
+    it { expect_no_offenses source, Pathname.pwd.join('packs/tool/app/public/tool.rb').to_s }
+  end
 end

--- a/spec/rubocop/cop/packs/class_methods_as_public_apis_spec.rb
+++ b/spec/rubocop/cop/packs/class_methods_as_public_apis_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe RuboCop::Cop::Packs::ClassMethodsAsPublicApis, :config do
     it { expect_no_offenses source, 'packs/tool/app/public/tool.rb' }
   end
 
-  context 'it inherits from T::Struct and defines a helper method' do
+  context 'when class inherits from T::Struct and defines a helper method' do
     let(:source) do
       <<~RUBY
         class Tool < T::Struct
@@ -137,7 +137,7 @@ RSpec.describe RuboCop::Cop::Packs::ClassMethodsAsPublicApis, :config do
     it { expect_no_offenses source, 'packs/tool/app/public/tool.rb' }
   end
 
-  context 'it inherits from T::Struct, includes TypedStructHelper, and defines a helper method' do
+  context 'when class inherits from T::Struct, includes TypedStructHelper, and defines a helper method' do
     let(:source) do
       <<~RUBY
         class Tool < T::Struct
@@ -151,7 +151,7 @@ RSpec.describe RuboCop::Cop::Packs::ClassMethodsAsPublicApis, :config do
     it { expect_no_offenses source, 'packs/tool/app/public/tool.rb' }
   end
 
-  context 'it inherits from T::Enum and defines a helper method' do
+  context 'when class inherits from T::Enum and defines a helper method' do
     let(:source) do
       <<~RUBY
         class MyEnum < T::Enum
@@ -169,5 +169,24 @@ RSpec.describe RuboCop::Cop::Packs::ClassMethodsAsPublicApis, :config do
     end
 
     it { expect_no_offenses source, Pathname.pwd.join(write_file('packs/tool/app/public/tool.rb')).to_s }
+  end
+
+  context 'when module is a sorbet interface' do
+    let(:source) do
+      <<~RUBY
+        module Tool
+          extend T::Sig
+          extend T::Helpers
+
+          interface!
+
+          sig { abstract.void }
+          def my_instance_method
+          end
+        end
+      RUBY
+    end
+
+    it { expect_no_offenses source, Pathname.pwd.join('packs/tool/app/public/tool.rb').to_s }
   end
 end


### PR DESCRIPTION
We want to exclude sorbet interfaces from this rule as they are great ways to define a public API.
