### PR TITLE
Allow mixins to be specified as allowed within Packs/ClassMethodsAsPublicApis

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-packs (0.0.27)
+    rubocop-packs (0.0.28)
       activesupport
       parse_packwerk
       rubocop

--- a/config/default.yml
+++ b/config/default.yml
@@ -5,6 +5,7 @@ Packs/ClassMethodsAsPublicApis:
     - T::Struct
     - Struct
     - OpenStruct
+  AcceptableMixins: []
   FailureMode: default
 
 Packs/RootNamespaceIsPackName:

--- a/lib/rubocop/cop/packs/class_methods_as_public_apis.rb
+++ b/lib/rubocop/cop/packs/class_methods_as_public_apis.rb
@@ -10,6 +10,7 @@ module RuboCop
       # Options:
       #
       # * `AcceptableParentClasses`: A list of classes that, if inherited from, non-class methods are permitted (useful when value objects are a part of your public API)
+      # * `AcceptableMixins`: A list of modules that, if included, non-class methods are permitted
       #
       # @example
       #

--- a/manual/cops_packs.md
+++ b/manual/cops_packs.md
@@ -12,6 +12,7 @@ searchable, and typically hold less state.
 Options:
 
 * `AcceptableParentClasses`: A list of classes that, if inherited from, non-class methods are permitted (useful when value objects are a part of your public API)
+* `AcceptableMixins`: A list of modules that, if included, non-class methods are permitted
 
 ### Examples
 
@@ -36,6 +37,7 @@ end
 Name | Default value | Configurable values
 --- | --- | ---
 AcceptableParentClasses | `T::Enum`, `T::Struct`, `Struct`, `OpenStruct` | Array
+AcceptableMixins | `[]` | Array
 FailureMode | `default` | String
 
 ## Packs/DocumentedPublicApis

--- a/rubocop-packs.gemspec
+++ b/rubocop-packs.gemspec
@@ -1,10 +1,10 @@
 Gem::Specification.new do |spec|
   spec.name          = 'rubocop-packs'
-  spec.version       = '0.0.27'
+  spec.version       = '0.0.28'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
-  spec.summary       = 'Fill this out!'
-  spec.description   = 'Fill this out!'
+  spec.summary       = 'A collection of Rubocop rules for gradually modularizing a ruby codebase'
+  spec.description   = 'A collection of Rubocop rules for gradually modularizing a ruby codebase'
   spec.homepage      = 'https://github.com/rubyatscale/rubocop-packs'
   spec.license       = 'MIT'
 

--- a/spec/rubocop/cop/packs/class_methods_as_public_apis_spec.rb
+++ b/spec/rubocop/cop/packs/class_methods_as_public_apis_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe RuboCop::Cop::Packs::ClassMethodsAsPublicApis, :config do
       'Mutations::BaseMutation' # GraphQL Mutation
     ]
   end
+  let(:acceptable_mixins) { [] }
+
   let(:cop_config) { { 'Enabled' => true, 'AcceptableParentClasses' => acceptable_parent_classes } }
   subject(:cop) { described_class.new(config) }
 
@@ -200,6 +202,22 @@ RSpec.describe RuboCop::Cop::Packs::ClassMethodsAsPublicApis, :config do
           abstract!
 
           sig { abstract.void }
+          def my_instance_method
+          end
+        end
+      RUBY
+    end
+
+    it { expect_no_offenses source, Pathname.pwd.join('packs/tool/app/public/tool.rb').to_s }
+  end
+
+  context 'when user has configured cop to ignore certain types of classes' do
+    let(:acceptable_mixins) { 'MyPermittedMixin' }
+    let(:cop_config) { { 'Enabled' => true, 'AcceptableParentClasses' => acceptable_parent_classes, 'AcceptableMixins' => acceptable_mixins } }
+    let(:source) do
+      <<~RUBY
+        class Tool
+          include MyPermittedMixin
           def my_instance_method
           end
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,7 @@ RSpec.configure do |config|
   config.include ApplicationFixtureHelper
   config.around do |example|
     ParsePackwerk.bust_cache!
+    RuboCop::Packs.bust_cache!
     example.run
   end
 


### PR DESCRIPTION
This is useful for things like Sidekiq jobs, which can be part of public API.