### PR TITLE
Fix issue regenerating rubocop TODO when cops are globally off

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-packs (0.0.28)
+    rubocop-packs (0.0.29)
       activesupport
       parse_packwerk
       rubocop

--- a/lib/rubocop/packs.rb
+++ b/lib/rubocop/packs.rb
@@ -35,9 +35,14 @@ module RuboCop
       end
 
       paths = packs.empty? ? files : packs.map(&:name).reject { |name| name == ParsePackwerk::ROOT_PACKAGE_NAME }
+
+      cop_names = config.permitted_pack_level_cops.select do |cop_name|
+        YAML.load_file('.rubocop.yml').fetch(cop_name, {})['Enabled']
+      end
+
       offenses = Private.offenses_for(
         paths: paths,
-        cop_names: config.permitted_pack_level_cops
+        cop_names: cop_names
       )
 
       offenses.group_by(&:pack).each do |pack, offenses_for_pack|

--- a/rubocop-packs.gemspec
+++ b/rubocop-packs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'rubocop-packs'
-  spec.version       = '0.0.28'
+  spec.version       = '0.0.29'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'A collection of Rubocop rules for gradually modularizing a ruby codebase'


### PR DESCRIPTION
Passing in `--only` into `rubocop` doesn't respect global configuration of a cop, unfortunately.
I tried to pass in `--force-exclusion` which doesn't fix the issue either.

I think this is a bit of a rubocop bug but fixing here for now.
