### PR TITLE
Fix issue where parent pack was overriding child pack's rubocop configuration

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-packs (0.0.31)
+    rubocop-packs (0.0.32)
       activesupport
       parse_packwerk
       rubocop
@@ -27,7 +27,7 @@ GEM
     minitest (5.16.3)
     netrc (0.11.0)
     parallel (1.22.1)
-    parse_packwerk (0.16.0)
+    parse_packwerk (0.17.0)
       sorbet-runtime
     parser (3.1.2.1)
       ast (~> 2.4.1)

--- a/lib/rubocop/packs.rb
+++ b/lib/rubocop/packs.rb
@@ -119,11 +119,15 @@ module RuboCop
 
           loaded_pack_rubocop = YAML.load_file(pack_rubocop)
           loaded_pack_rubocop.each do |cop_name, key_config|
-            next unless key_config['Enabled']
-
             rubocop_config[cop_name] ||= {}
-            rubocop_config[cop_name]['Include'] ||= []
-            rubocop_config[cop_name]['Include'] << package.directory.join('**/*').to_s
+
+            if key_config['Enabled']
+              rubocop_config[cop_name]['Include'] ||= []
+              rubocop_config[cop_name]['Include'] << package.directory.join('**/*').to_s
+            else
+              rubocop_config[cop_name]['Exclude'] ||= []
+              rubocop_config[cop_name]['Exclude'] << package.directory.join('**/*').to_s
+            end
           end
         end
       end

--- a/rubocop-packs.gemspec
+++ b/rubocop-packs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'rubocop-packs'
-  spec.version       = '0.0.31'
+  spec.version       = '0.0.32'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'A collection of Rubocop rules for gradually modularizing a ruby codebase'


### PR DESCRIPTION
A parent pack can turn on a cop, which would override the child excluding it. I explicitly exclude packs that have opted out to fix this bug.
