### PR TITLE
Update documentation in Rubocop cop DocumentedPublicApis

### DIFF
--- a/lib/rubocop/cop/packs/documented_public_apis.rb
+++ b/lib/rubocop/cop/packs/documented_public_apis.rb
@@ -14,10 +14,19 @@ module RuboCop
       #     def bar; end
       #   end
       #
+      #   # good
       #   # packs/foo/app/public/foo.rb
       #   class Foo
       #     # This is a documentation comment.
-      #     # It can live below or below a sorbet type signature.
+      #     def bar; end
+      #   end
+      #
+      #   # good
+      #   # packs/foo/app/public/foo.rb
+      #   class Foo
+      #     # This is a documentation comment.
+      #     # It should appear above a sorbet type signature
+      #     sig { void }
       #     def bar; end
       #   end
       #

--- a/manual/cops_packs.md
+++ b/manual/cops_packs.md
@@ -58,10 +58,19 @@ class Foo
   def bar; end
 end
 
+# good
 # packs/foo/app/public/foo.rb
 class Foo
   # This is a documentation comment.
-  # It can live below or below a sorbet type signature.
+  def bar; end
+end
+
+# good
+# packs/foo/app/public/foo.rb
+class Foo
+  # This is a documentation comment.
+  # It should appear above a sorbet type signature
+  sig { void }
   def bar; end
 end
 ```

--- a/tasks/cop_documentation.rake
+++ b/tasks/cop_documentation.rake
@@ -264,7 +264,7 @@ task generate_cops_documentation: :yard_for_generate_documentation do
       sh('GIT_PAGER=cat git diff manual')
 
       warn('The manual directory is out of sync. ' \
-           'Run `rake generate_cops_documentation` and commit the results.')
+           'Run `VERIFYING_DOCUMENTATION=true rake generate_cops_documentation` and commit the results.')
       exit!
     end
   end


### PR DESCRIPTION
Problem
-------

If you read the docs in the cop, it suggests that you can put the function documentation string before or after a sorbet sig.

But if you read the specs, (or try it locally) you get rubocop errors because it actually requires the comment to come before the sig.

Solution
---------

Update the docs to match the actual behavior.

The failing spec is `when class defines an instance method with a sig and with documentation below the sig`. 

https://github.com/rubyatscale/rubocop-packs/blob/a8245b5952355792d10e09b327290c453f5d6ea8/spec/rubocop/cop/packs/documented_public_apis_spec.rb#L74