### PR TITLE
Update required ruby version to 2.7

### DIFF
--- a/rubocop-packs.gemspec
+++ b/rubocop-packs.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   # Specify which files should be added to the gem when it is released.
   spec.files = Dir['README.md', 'lib/**/*', 'config/default.yml', 'config/pack_config.yml']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6'
+  spec.required_ruby_version = '>= 2.7'
 
   spec.add_dependency 'activesupport'
   spec.add_dependency 'parse_packwerk'


### PR DESCRIPTION
problem
-------

If you pull this repo and `bundle install` on an old version of ruby (< 2.7), you'll get a sort of obscure error message

```bash
$ bundle install
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies....
activesupport-7.0.4 requires ruby version >= 2.7.0, which is incompatible with the current version,
ruby 2.6.6p146
```

I saw this and asked - "why do I care about `activesupport-7`?"

Currently, the gemspec has `spec.required_ruby_version = '>= 2.6'`.

proposed solution
-----------------

If we actually want to depend on activesupport-7.0.4 which requires ruby >= 2.7, then let's specify that in the gemspec.

Though I think that is more accurate, I will call out that it generates far more error messaging in the case where we're using ruby 2.6.6 and we `bundle install`.

```bash

$ bundle install
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies.....
Bundler found conflicting requirements for the Ruby version:
  In Gemfile:
    Ruby

    rubocop-extension-generator was resolved to 0.5.1, which depends on
      activesupport was resolved to 7.0.4, which depends on
        minitest (>= 5.1) was resolved to 5.16.3, which depends on
          Ruby (>= 2.6, < 4.0)

    parser was resolved to 3.1.2.1, which depends on
      Ruby (>= 2.0.0)

    rspec (~> 3.0) was resolved to 3.11.0, which depends on
      rspec-expectations (~> 3.11.0) was resolved to 3.11.1, which depends on
        Ruby (>= 1.8.7)

    rubocop-extension-generator was resolved to 0.5.1, which depends on
      Ruby (>= 2.6.0)

    rubocop-packs was resolved to 0.0.32, which depends on
      Ruby (>= 2.7)

    rubocop-extension-generator was resolved to 0.5.1, which depends on
      rubocop (>= 1.22.0) was resolved to 1.36.0, which depends on
        unicode-display_width (>= 1.4.0, < 3.0) was resolved to 2.3.0, which depends on
          Ruby (>= 1.9.3)

    tapioca was resolved to 0.10.2, which depends on
      yard-sorbet was resolved to 0.7.0, which depends on
        yard (>= 0.9) was resolved to 0.9.28, which depends on
          webrick (~> 1.7.0) was resolved to 1.7.0, which depends on
            Ruby (>= 2.3.0)

Ruby (>= 2.7), which is required by gem 'rubocop-packs', is not available in the local ruby
installation
Bundler could not find compatible versions for gem "activesupport":
  In snapshot (Gemfile.lock):
    activesupport (= 7.0.4)

... and about 75 more lines of "incompatible versions" reports
```

Even with that output, this feels like the configuration file is properly specifying the requirements and this error stream *does* include

```
Ruby (>= 2.7), which is required by gem 'rubocop-packs', is not available in the local ruby
installation
```

which highlights the problem.  So I feel like this might be the right direction.