### PR TITLE
Remove unnecessary test setup complexity

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,7 @@
 #
 # See https://docs.rubocop.org/rubocop/configuration
 AllCops:
+  SuggestExtensions: false
   NewCops: enable
   Exclude:
     - vendor/bundle/**/**

--- a/lib/rubocop/cop/packs/root_namespace_is_pack_name.rb
+++ b/lib/rubocop/cop/packs/root_namespace_is_pack_name.rb
@@ -39,8 +39,6 @@ module RuboCop
 
           relative_filename = relative_filepath.to_s
           package_for_path = ParsePackwerk.package_from_path(relative_filename)
-          # If a pack is using automatic pack namespaces, this protection is a no-op since zeitwerk will enforce single namespaces in that case.
-          return if package_for_path.metadata['automatic_pack_namespace']
 
           return if package_for_path.nil?
 

--- a/spec/rubocop/cop/packs/root_namespace_is_pack_name_spec.rb
+++ b/spec/rubocop/cop/packs/root_namespace_is_pack_name_spec.rb
@@ -356,23 +356,4 @@ RSpec.describe RuboCop::Cop::Packs::RootNamespaceIsPackName, :config do
       it { expect_no_offenses source, Pathname.pwd.join(write_file('packs/fruits/apples/app/models/concerns/apples.rb')).to_s }
     end
   end
-
-  context 'a pack uses custom zeitwerk namespaces' do
-    before do
-      write_package_yml('packs/apples', automatic_pack_namespace: true)
-    end
-
-    context 'when file establishes different namespace' do
-      let(:source) do
-        <<~RUBY
-          module Apples
-            class Tool
-            end
-          end
-        RUBY
-      end
-
-      it { expect_no_offenses source, Pathname.pwd.join(write_file('packs/apples/app/services/tool.rb')).to_s }
-    end
-  end
 end

--- a/spec/rubocop/cop/packwerk_lite/dependency_checker_spec.rb
+++ b/spec/rubocop/cop/packwerk_lite/dependency_checker_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe RuboCop::Cop::PackwerkLite::Dependency, :config do
   context 'namespacing convention is being followed' do
     context 'unstated dependency used' do
       before do
-        write_package_yml('packs/apples')
-        write_package_yml('packs/tools')
+        write_package_yml('packs/apples', 'enforce_dependencies' => true)
+        write_package_yml('packs/tools', 'enforce_dependencies' => true)
         write_file('packs/apples/app/public/apples.rb')
         write_file('packs/tools/app/public/tool.rb')
       end
@@ -27,7 +27,7 @@ RSpec.describe RuboCop::Cop::PackwerkLite::Dependency, :config do
 
     context 'a partially qualified constant defined in same pack is use' do
       before do
-        write_package_yml('packs/tools')
+        write_package_yml('packs/tools', 'enforce_dependencies' => true)
         write_file('packs/tools/app/services/tools/private.rb')
         write_file('packs/tools/app/public/tool.rb')
       end
@@ -45,7 +45,7 @@ RSpec.describe RuboCop::Cop::PackwerkLite::Dependency, :config do
 
     context 'a fully qualified constant defined in same pack is use' do
       before do
-        write_package_yml('packs/tools')
+        write_package_yml('packs/tools', 'enforce_dependencies' => true)
         write_file('packs/tools/app/services/tools/private.rb')
         write_file('packs/tools/app/public/tool.rb')
       end
@@ -63,8 +63,8 @@ RSpec.describe RuboCop::Cop::PackwerkLite::Dependency, :config do
 
     context 'unstated dependency with multiple namespaces used' do
       before do
-        write_package_yml('packs/apples')
-        write_package_yml('packs/tools')
+        write_package_yml('packs/apples', 'enforce_dependencies' => true)
+        write_package_yml('packs/tools', 'enforce_dependencies' => true)
         write_file('packs/apples/app/services/apples/green.rb')
         write_file('packs/tools/app/public/tool.rb')
       end
@@ -83,8 +83,8 @@ RSpec.describe RuboCop::Cop::PackwerkLite::Dependency, :config do
 
     context 'stated dependency is used' do
       before do
-        write_package_yml('packs/apples')
-        write_package_yml('packs/tools', dependencies: ['packs/apples'])
+        write_package_yml('packs/apples', 'enforce_dependencies' => true)
+        write_package_yml('packs/tools', 'enforce_dependencies' => true, 'dependencies' => ['packs/apples'])
         write_file('packs/apples/app/public/apples.rb')
         write_file('packs/tools/app/public/tool.rb')
       end
@@ -104,8 +104,8 @@ RSpec.describe RuboCop::Cop::PackwerkLite::Dependency, :config do
   context 'namespacing convention is not being followed' do
     context 'unstated dependency used' do
       before do
-        write_package_yml('packs/apples')
-        write_package_yml('packs/tools')
+        write_package_yml('packs/apples', 'enforce_dependencies' => true)
+        write_package_yml('packs/tools', 'enforce_dependencies' => true)
         write_file('packs/apples/app/public/public_api.rb')
         write_file('packs/tools/app/public/tool.rb')
       end
@@ -123,7 +123,7 @@ RSpec.describe RuboCop::Cop::PackwerkLite::Dependency, :config do
 
     context 'a fully qualified constant defined in same pack is use' do
       before do
-        write_package_yml('packs/tools')
+        write_package_yml('packs/tools', 'enforce_dependencies' => true)
         write_file('packs/tools/app/services/some_other_namespace/private.rb')
         write_file('packs/tools/app/public/tool.rb')
       end
@@ -141,8 +141,8 @@ RSpec.describe RuboCop::Cop::PackwerkLite::Dependency, :config do
 
     context 'unstated dependency with multiple namespaces used' do
       before do
-        write_package_yml('packs/apples')
-        write_package_yml('packs/tools')
+        write_package_yml('packs/apples', 'enforce_dependencies' => true)
+        write_package_yml('packs/tools', 'enforce_dependencies' => true)
         write_file('packs/apples/app/services/blah/green.rb')
         write_file('packs/tools/app/public/tool.rb')
       end
@@ -160,8 +160,8 @@ RSpec.describe RuboCop::Cop::PackwerkLite::Dependency, :config do
 
     context 'stated dependency is used' do
       before do
-        write_package_yml('packs/apples')
-        write_package_yml('packs/tools', dependencies: ['packs/apples'])
+        write_package_yml('packs/apples', 'enforce_dependencies' => true)
+        write_package_yml('packs/tools', 'enforce_dependencies' => true, 'dependencies' => ['packs/apples'])
         write_file('packs/apples/app/public/blah.rb')
         write_file('packs/tools/app/public/tool.rb')
       end

--- a/spec/rubocop/cop/packwerk_lite/privacy_checker_spec.rb
+++ b/spec/rubocop/cop/packwerk_lite/privacy_checker_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe RuboCop::Cop::PackwerkLite::Privacy, :config do
   context 'namespace convention is being followed' do
     context 'a private API is used from a private folder' do
       before do
-        write_package_yml('packs/apples')
+        write_package_yml('packs/apples', 'enforce_privacy' => true)
         write_file('packs/apples/app/services/apples.rb')
-        write_package_yml('packs/tools')
+        write_package_yml('packs/tools', 'enforce_privacy' => true)
         write_file('packs/tools/app/services/tools.rb')
       end
 
@@ -27,9 +27,9 @@ RSpec.describe RuboCop::Cop::PackwerkLite::Privacy, :config do
 
     context 'a private API is used from the public folder' do
       before do
-        write_package_yml('packs/apples')
+        write_package_yml('packs/apples', 'enforce_privacy' => true)
         write_file('packs/apples/app/public/apples.rb')
-        write_package_yml('packs/tools')
+        write_package_yml('packs/tools', 'enforce_privacy' => true)
         write_file('packs/tools/app/services/tools.rb')
       end
 
@@ -47,9 +47,9 @@ RSpec.describe RuboCop::Cop::PackwerkLite::Privacy, :config do
 
     context 'a public API is used from a private folder' do
       before do
-        write_package_yml('packs/apples')
+        write_package_yml('packs/apples', 'enforce_privacy' => true)
         write_file('packs/apples/app/public/apples.rb')
-        write_package_yml('packs/tools')
+        write_package_yml('packs/tools', 'enforce_privacy' => true)
         write_file('packs/tools/app/public/tools.rb')
       end
 
@@ -68,9 +68,9 @@ RSpec.describe RuboCop::Cop::PackwerkLite::Privacy, :config do
   context 'namespace convention is not being followed' do
     context 'a private API is used from a private folder' do
       before do
-        write_package_yml('packs/apples')
+        write_package_yml('packs/apples', 'enforce_privacy' => true)
         write_file('packs/apples/app/services/apples.rb')
-        write_package_yml('packs/tools')
+        write_package_yml('packs/tools', 'enforce_privacy' => true)
         write_file('packs/tools/app/services/blah.rb')
       end
 
@@ -87,9 +87,9 @@ RSpec.describe RuboCop::Cop::PackwerkLite::Privacy, :config do
 
     context 'a private API is used from the public folder' do
       before do
-        write_package_yml('packs/apples')
+        write_package_yml('packs/apples', 'enforce_privacy' => true)
         write_file('packs/apples/app/public/apples.rb')
-        write_package_yml('packs/tools')
+        write_package_yml('packs/tools', 'enforce_privacy' => true)
         write_file('packs/tools/app/services/blah.rb')
       end
 
@@ -106,9 +106,9 @@ RSpec.describe RuboCop::Cop::PackwerkLite::Privacy, :config do
 
     context 'a public API is used from a private folder' do
       before do
-        write_package_yml('packs/apples')
+        write_package_yml('packs/apples', 'enforce_privacy' => true)
         write_file('packs/apples/app/public/apples.rb')
-        write_package_yml('packs/tools')
+        write_package_yml('packs/tools', 'enforce_privacy' => true)
         write_file('packs/tools/app/public/blah.rb')
       end
 
@@ -125,10 +125,10 @@ RSpec.describe RuboCop::Cop::PackwerkLite::Privacy, :config do
 
     context 'packs share a sub-module namespace and do not fully qualify the constant' do
       before do
-        write_package_yml('packs/apples')
+        write_package_yml('packs/apples', 'enforce_privacy' => true)
         write_file('packs/apples/app/public/apples.rb')
         write_file('packs/apples/app/public/apples/tools/pruners.rb')
-        write_package_yml('packs/tools')
+        write_package_yml('packs/tools', 'enforce_privacy' => true)
         write_file('packs/tools/app/services/tools/pruners.rb')
       end
 
@@ -148,10 +148,10 @@ RSpec.describe RuboCop::Cop::PackwerkLite::Privacy, :config do
 
     context 'packs share a sub-module namespace and does fully qualify the constant' do
       before do
-        write_package_yml('packs/apples')
+        write_package_yml('packs/apples', 'enforce_privacy' => true)
         write_file('packs/apples/app/public/apples.rb')
         write_file('packs/apples/app/public/apples/tools/pruners.rb')
-        write_package_yml('packs/tools')
+        write_package_yml('packs/tools', 'enforce_privacy' => true)
         write_file('packs/tools/app/services/tools/pruners.rb')
       end
 

--- a/spec/support/application_fixture_helper.rb
+++ b/spec/support/application_fixture_helper.rb
@@ -20,19 +20,16 @@ module ApplicationFixtureHelper
       dependencies: T::Array[String],
       enforce_dependencies: T::Boolean,
       enforce_privacy: T::Boolean,
-      automatic_pack_namespace: T::Boolean
     ).void
   end
   def write_package_yml(
     pack_name,
     dependencies: [],
     enforce_dependencies: true,
-    enforce_privacy: true,
-    automatic_pack_namespace: false
+    enforce_privacy: true
   )
 
     metadata = {}
-    metadata.merge!('automatic_pack_namespace' => true) if automatic_pack_namespace
 
     package = ParsePackwerk::Package.new(
       name: pack_name,

--- a/spec/support/application_fixture_helper.rb
+++ b/spec/support/application_fixture_helper.rb
@@ -17,29 +17,15 @@ module ApplicationFixtureHelper
   sig do
     params(
       pack_name: String,
-      dependencies: T::Array[String],
-      enforce_dependencies: T::Boolean,
-      enforce_privacy: T::Boolean,
+      config: T::Hash[T.untyped, T.untyped]
     ).void
   end
   def write_package_yml(
     pack_name,
-    dependencies: [],
-    enforce_dependencies: true,
-    enforce_privacy: true
+    config = {}
   )
-
-    metadata = {}
-
-    package = ParsePackwerk::Package.new(
-      name: pack_name,
-      dependencies: dependencies,
-      enforce_dependencies: enforce_dependencies,
-      enforce_privacy: enforce_privacy,
-      metadata: metadata
-    )
-
-    ParsePackwerk.write_package_yml!(package)
+    path = Pathname.pwd.join(pack_name).join('package.yml')
+    write_file(path.to_s, YAML.dump(config))
   end
 
   sig { params(path: String).void }


### PR DESCRIPTION
For `rubocop-packs` to use `packs` instead of `parse_packwerk`, test setup shouldn't rely on `parse_packwerk`.