### PR TITLE
Revert "Use vanilla rubocop tools for per-pack rubocop config (#59)"

### DIFF
--- a/ADVANCED_USAGE.md
+++ b/ADVANCED_USAGE.md
@@ -1,39 +1,32 @@
 # Advanced Usage
 
-## Pack-Level `.rubocop.yml` and `.rubocop_todo.yml` files
+## Pack-Level `package_rubocop.yml` and `package_rubocop_todo.yml` files
 `rubocop-packs` also has some API that help you use rubocop in a pack-based context.
 
-### Per-pack `.rubocop.yml`
-While `rubocop-packs` can be used like any other `rubocop` by configuring in your top-level `.rubocop.yml` file, we also have a number of tools to support per-pack configuration.
-
-To add a per-pack `.rubocop.yml`, you just need to create a `packs/your_pack/.rubocop.yml`. With this, each pack can specify an allow-listed set of cops (see below) that can be configured on a per-package level, while extending the root level config.
-
-Example:
+### Basic Configuration
+In your top-level `.rubocop.yml` file, you'll want to include configuration from `rubocop-packs`:
 ```yml
-inherit_from: '../../.rubocop.yml'
-
-Packs/TypedPublicApis:
-  Enabled: true
-
-Packs/RootNamespaceIsPackName:
-  Enabled: true
-
-Packs/DocumentedPublicApis:
-  Enabled: false
-
-Sorbet/StrictSigil:
-  Enabled: false
+inherit_gem:
+  rubocop-packs:
+    - config/default.yml
 ```
 
-### Per-pack `.rubocop_todo.yml`
-To create a per-pack `.rubocop_todo.yml`, you can use the following API from `rubocop-packs`:
+This is the mechanism by which pack level rubocop files are incorporated into the top-level config.
+
+### Per-pack `package_rubocop.yml`
+While `rubocop-packs` can be used like any other `rubocop` by configuring in your top-level `.rubocop.yml` file, we also have a number of tools to support per-pack configuration.
+
+To add a per-pack `package_rubocop.yml`, you just need to create a `packs/your_pack/package_rubocop.yml`. With this, each pack can specify an allow-listed set of cops (see below) that can be configured on a per-package level.
+
+### Per-pack `package_rubocop_todo.yml`
+To create a per-pack `package_rubocop_todo.yml`, you can use the following API from `rubocop-packs`:
 ```ruby
 RuboCop::Packs.regenerate_todo(packs: Packs.all)
 ```
-This API will auto-generate a `packs/some_pack/.rubocop_todo.yml`. This allows a pack to own its own exception list.
+This API will auto-generate a `packs/some_pack/package_rubocop_todo.yml`. This allows a pack to own its own exception list.
 
 ### Configuration and Validation
-To use per-pack `.rubocop.yml` and `.rubocop_todo.yml` files, you need to configure `rubocop-packs`:
+To use per-pack `package_rubocop.yml` and `package_rubocop_todo.yml` files, you need to configure `rubocop-packs`:
 ```ruby
 # config/rubocop_packs.rb
 RuboCop::Packs.configure do |config|
@@ -50,5 +43,5 @@ end
 ```
 
 Validations include:
-- Ensuring that `packs/*/.rubocop_todo.yml` files only contain exceptions for the allow-list of `permitted_pack_level_cops`
-- Ensuring that `packs/*/.rubocop.yml` files contain all of the cops listed in `required_pack_level_cops` and no other cops. This is to ensure that these files are only used to turn on and off an allow-list of cops, as most users would not want packs to configure most `rubocop` rules in a way that is different from the rest of the application.
+- Ensuring that `packs/*/package_rubocop_todo.yml` files only contain exceptions for the allow-list of `permitted_pack_level_cops`
+- Ensuring that `packs/*/package_rubocop.yml` files contain all of the cops listed in `required_pack_level_cops` and no other cops. This is to ensure that these files are only used to turn on and off an allow-list of cops, as most users would not want packs to configure most `rubocop` rules in a way that is different from the rest of the application.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-packs (0.0.36)
+    rubocop-packs (0.0.35)
       activesupport
       packs
       parse_packwerk
@@ -30,7 +30,7 @@ GEM
     packs (0.0.6)
       sorbet-runtime
     parallel (1.22.1)
-    parse_packwerk (0.18.2)
+    parse_packwerk (0.18.0)
       sorbet-runtime
     parser (3.1.2.1)
       ast (~> 2.4.1)
@@ -75,7 +75,7 @@ GEM
       activesupport
       bundler
       rubocop (>= 1.22.0)
-    rubocop-sorbet (0.7.0)
+    rubocop-sorbet (0.6.11)
       rubocop (>= 0.90.0)
     ruby-progressbar (1.11.0)
     sorbet (0.5.10479)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Packs/RootNamespaceIsPackName:
     - lib/example.rb
 ```
 
-## Pack-Level `.rubocop.yml` and `.rubocop_todo.yml` files
+## Pack-Level `package_rubocop.yml` and `package_rubocop_todo.yml` files
 See [ADVANCED_USAGE.md](ADVANCED_USAGE.md)
 
 ## Contributing

--- a/config/default.yml
+++ b/config/default.yml
@@ -27,3 +27,11 @@ PackwerkLite/Privacy:
 PackwerkLite/Dependency:
   # It is recommended to use packwerk
   Enabled: false
+
+# We do this inherit *after* setting the defaults so that pack-specific rubocops can override the defaults
+# Relevant documentation:
+#  - Inheriting config from a gem:
+#    - https://docs.rubocop.org/rubocop/configuration.html#inheriting-configuration-from-a-dependency-gem
+#  - ERB in a .rubocop.yml file
+#    - https://docs.rubocop.org/rubocop/configuration.html#pre-processing
+<%= RuboCop::Packs.pack_based_rubocop_config %>

--- a/docs/packwerk_lite.md
+++ b/docs/packwerk_lite.md
@@ -16,7 +16,7 @@ So why would we want to do this...?
 - Experimentally and hypothetically, as a way to provide early feedback loop for engineers who are more familiar with rubocop
 
 What is missing?
-- In order to run this, we need to read from AND write to `package_todo.yml` file so that they pick up and ignore the same things (right now we only read from). We'd likely also need to expose a validation to allow the client to confirm that the `**/.rubocop_todo.yml` entries for `PackwerkLite/Privacy` and `PackwerkLite/Dependency` are empty.
+- In order to run this, we need to read from AND write to `package_todo.yml` file so that they pick up and ignore the same things (right now we only read from). We'd likely also need to expose a validation to allow the client to confirm that the `**/package_rubocop_todo.yml` entries for `PackwerkLite/Privacy` and `PackwerkLite/Dependency` are empty.
 - There were very few false positives (things this picked up that `packwerk` did not) in Gusto's codebase, but we'd want to address those too.
 
 # Appendix

--- a/lib/rubocop/packs/private.rb
+++ b/lib/rubocop/packs/private.rb
@@ -87,8 +87,6 @@ module RuboCop
         end
 
         loaded_rubocop_yml.each_key do |key|
-          next if key == 'inherit_from'
-
           if !Packs.config.permitted_pack_level_cops.include?(key)
             errors << <<~ERROR_MESSAGE
               #{rubocop_yml} contains invalid configuration for #{key}.

--- a/rubocop-packs.gemspec
+++ b/rubocop-packs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'rubocop-packs'
-  spec.version       = '0.0.36'
+  spec.version       = '0.0.35'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'A collection of Rubocop rules for gradually modularizing a ruby codebase'
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   end
 
   # Specify which files should be added to the gem when it is released.
-  spec.files = Dir['README.md', 'lib/**/*', 'config/default.yml']
+  spec.files = Dir['README.md', 'lib/**/*', 'config/default.yml', 'config/pack_config.yml']
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.7'
 

--- a/spec/rubocop/packs_spec.rb
+++ b/spec/rubocop/packs_spec.rb
@@ -16,9 +16,9 @@ RSpec.describe RuboCop::Packs do
       end
     end
 
-    let(:rubocop_yml) { Packs.find('packs/my_pack').relative_path.join('.rubocop.yml') }
+    let(:rubocop_yml) { Packs.find('packs/my_pack').relative_path.join('package_rubocop.yml') }
 
-    it 'generates a .rubocop.yml with the right required pack level cops' do
+    it 'generates a package_rubocop.yml with the right required pack level cops' do
       expect(rubocop_yml).to_not exist
       RuboCop::Packs.set_default_rubocop_yml(packs: Packs.all)
       expect(rubocop_yml).to exist
@@ -28,7 +28,7 @@ RSpec.describe RuboCop::Packs do
                                                 })
     end
 
-    it 'formats the .rubocop.yml file nicely' do
+    it 'formats the package_rubocop.yml file nicely' do
       expect(rubocop_yml).to_not exist
       RuboCop::Packs.set_default_rubocop_yml(packs: Packs.all)
       expect(rubocop_yml).to exist
@@ -43,7 +43,7 @@ RSpec.describe RuboCop::Packs do
   end
 
   describe 'regenerate_todo' do
-    let(:rubocop_todo_yml) { Pathname.new('packs/my_pack/.rubocop_todo.yml') }
+    let(:rubocop_todo_yml) { Pathname.new('packs/my_pack/package_rubocop_todo.yml') }
 
     let(:cop_cli_args) do
       '--only=Packs/RootNamespaceIsPackName,Packs/TypedPublicApis,Packs/ClassMethodsAsPublicApis'
@@ -74,7 +74,7 @@ RSpec.describe RuboCop::Packs do
 
     context 'regenerating TODO for entire packs' do
       context 'pack has no current rubocop todo' do
-        before { write_file('packs/my_pack/.rubocop.yml') }
+        before { write_file('packs/my_pack/package_rubocop.yml') }
 
         it 'creates the TODO' do
           expect(rubocop_todo_yml).to_not exist
@@ -82,8 +82,8 @@ RSpec.describe RuboCop::Packs do
           expect(rubocop_todo_yml).to exist
           expect(YAML.load_file(rubocop_todo_yml)).to eq(
             {
-              'Packs/RootNamespaceIsPackName' => { 'Exclude' => ['path/to/file.rb'] },
-              'Packs/ClassMethodsAsPublicApis' => { 'Exclude' => ['path/to/file.rb'] }
+              'Packs/RootNamespaceIsPackName' => { 'Exclude' => ['packs/my_pack/path/to/file.rb'] },
+              'Packs/ClassMethodsAsPublicApis' => { 'Exclude' => ['packs/my_pack/path/to/file.rb'] }
             }
           )
         end
@@ -99,12 +99,12 @@ RSpec.describe RuboCop::Packs do
 
       context 'pack has an existing rubocop todo' do
         before do
-          write_file('packs/my_pack/.rubocop.yml')
+          write_file('packs/my_pack/package_rubocop.yml')
           rubocop_todo_yml.write(
             YAML.dump(
               {
-                'Packs/RootNamespaceIsPackName' => { 'Exclude' => ['path/to/existing_file.rb'] },
-                'Packs/TypedPublicApis' => { 'Exclude' => ['path/to/file.rb'] }
+                'Packs/RootNamespaceIsPackName' => { 'Exclude' => ['packs/my_pack/path/to/existing_file.rb'] },
+                'Packs/TypedPublicApis' => { 'Exclude' => ['packs/my_pack/path/to/file.rb'] }
               }
             )
           )
@@ -116,8 +116,8 @@ RSpec.describe RuboCop::Packs do
           expect(rubocop_todo_yml).to exist
           expect(YAML.load_file(rubocop_todo_yml)).to eq(
             {
-              'Packs/RootNamespaceIsPackName' => { 'Exclude' => ['path/to/file.rb'] },
-              'Packs/ClassMethodsAsPublicApis' => { 'Exclude' => ['path/to/file.rb'] }
+              'Packs/RootNamespaceIsPackName' => { 'Exclude' => ['packs/my_pack/path/to/file.rb'] },
+              'Packs/ClassMethodsAsPublicApis' => { 'Exclude' => ['packs/my_pack/path/to/file.rb'] }
             }
           )
         end
@@ -125,7 +125,7 @@ RSpec.describe RuboCop::Packs do
 
       # This can happen because a cop can fail on multiple lines in the same file
       context 'pack has multiple offenses for the same file' do
-        before { write_file('packs/my_pack/.rubocop.yml') }
+        before { write_file('packs/my_pack/package_rubocop.yml') }
 
         let(:offenses) do
           [{ 'cop_name' => 'Packs/RootNamespaceIsPackName' }, { 'cop_name' => 'Packs/ClassMethodsAsPublicApis' }, { 'cop_name' => 'Packs/ClassMethodsAsPublicApis' }, { 'cop_name' => 'Packs/ClassMethodsAsPublicApis' }]
@@ -136,8 +136,8 @@ RSpec.describe RuboCop::Packs do
           expect(rubocop_todo_yml).to exist
           expect(YAML.load_file(rubocop_todo_yml)).to eq(
             {
-              'Packs/ClassMethodsAsPublicApis' => { 'Exclude' => ['path/to/file.rb'] },
-              'Packs/RootNamespaceIsPackName' => { 'Exclude' => ['path/to/file.rb'] }
+              'Packs/ClassMethodsAsPublicApis' => { 'Exclude' => ['packs/my_pack/path/to/file.rb'] },
+              'Packs/RootNamespaceIsPackName' => { 'Exclude' => ['packs/my_pack/path/to/file.rb'] }
             }
           )
         end
@@ -151,7 +151,7 @@ RSpec.describe RuboCop::Packs do
             Packs/RootNamespaceIsPackName:
               Enabled: true
           YML
-          write_file('packs/my_pack/.rubocop.yml')
+          write_file('packs/my_pack/package_rubocop.yml')
         end
 
         let(:offenses) do
@@ -165,7 +165,7 @@ RSpec.describe RuboCop::Packs do
           expect(rubocop_todo_yml).to exist
           expect(YAML.load_file(rubocop_todo_yml)).to eq(
             {
-              'Packs/RootNamespaceIsPackName' => { 'Exclude' => ['path/to/file.rb'] }
+              'Packs/RootNamespaceIsPackName' => { 'Exclude' => ['packs/my_pack/path/to/file.rb'] }
             }
           )
         end
@@ -179,7 +179,7 @@ RSpec.describe RuboCop::Packs do
             Packs/RootNamespaceIsPackName:
               Enabled: true
           YML
-          write_file('packs/my_pack/.rubocop.yml')
+          write_file('packs/my_pack/package_rubocop.yml')
         end
 
         let(:cop_cli_args) { '--only=Packs/RootNamespaceIsPackName' }
@@ -192,8 +192,8 @@ RSpec.describe RuboCop::Packs do
           expect(rubocop_todo_yml).to exist
           expect(YAML.load_file(rubocop_todo_yml)).to eq(
             {
-              'Packs/RootNamespaceIsPackName' => { 'Exclude' => ['path/to/file.rb'] },
-              'Packs/ClassMethodsAsPublicApis' => { 'Exclude' => ['path/to/file.rb'] }
+              'Packs/RootNamespaceIsPackName' => { 'Exclude' => ['packs/my_pack/path/to/file.rb'] },
+              'Packs/ClassMethodsAsPublicApis' => { 'Exclude' => ['packs/my_pack/path/to/file.rb'] }
             }
           )
         end
@@ -202,7 +202,7 @@ RSpec.describe RuboCop::Packs do
 
     context 'regenerating TODO for one file' do
       context 'pack has no current rubocop todo' do
-        before { write_file('packs/my_pack/.rubocop.yml') }
+        before { write_file('packs/my_pack/package_rubocop.yml') }
 
         it 'creates the TODO' do
           expect(rubocop_todo_yml).to_not exist
@@ -210,8 +210,8 @@ RSpec.describe RuboCop::Packs do
           expect(rubocop_todo_yml).to exist
           expect(YAML.load_file(rubocop_todo_yml)).to eq(
             {
-              'Packs/RootNamespaceIsPackName' => { 'Exclude' => ['path/to/file.rb'] },
-              'Packs/ClassMethodsAsPublicApis' => { 'Exclude' => ['path/to/file.rb'] }
+              'Packs/RootNamespaceIsPackName' => { 'Exclude' => ['packs/my_pack/path/to/file.rb'] },
+              'Packs/ClassMethodsAsPublicApis' => { 'Exclude' => ['packs/my_pack/path/to/file.rb'] }
             }
           )
         end
@@ -230,12 +230,12 @@ RSpec.describe RuboCop::Packs do
           rubocop_todo_yml.write(
             YAML.dump(
               {
-                'Packs/RootNamespaceIsPackName' => { 'Exclude' => ['path/to/existing_file.rb'] },
-                'Packs/TypedPublicApis' => { 'Exclude' => ['path/to/file.rb'] }
+                'Packs/RootNamespaceIsPackName' => { 'Exclude' => ['packs/my_pack/path/to/existing_file.rb'] },
+                'Packs/TypedPublicApis' => { 'Exclude' => ['packs/my_pack/path/to/file.rb'] }
               }
             )
           )
-          write_file('packs/my_pack/.rubocop.yml')
+          write_file('packs/my_pack/package_rubocop.yml')
         end
 
         it 'adds to the TODO with the new files' do
@@ -244,9 +244,9 @@ RSpec.describe RuboCop::Packs do
           expect(rubocop_todo_yml).to exist
           expect(YAML.load_file(rubocop_todo_yml)).to eq(
             {
-              'Packs/RootNamespaceIsPackName' => { 'Exclude' => ['path/to/existing_file.rb', 'path/to/file.rb'] },
-              'Packs/TypedPublicApis' => { 'Exclude' => ['path/to/file.rb'] },
-              'Packs/ClassMethodsAsPublicApis' => { 'Exclude' => ['path/to/file.rb'] }
+              'Packs/RootNamespaceIsPackName' => { 'Exclude' => ['packs/my_pack/path/to/existing_file.rb', 'packs/my_pack/path/to/file.rb'] },
+              'Packs/TypedPublicApis' => { 'Exclude' => ['packs/my_pack/path/to/file.rb'] },
+              'Packs/ClassMethodsAsPublicApis' => { 'Exclude' => ['packs/my_pack/path/to/file.rb'] }
             }
           )
         end
@@ -270,7 +270,7 @@ RSpec.describe RuboCop::Packs do
       end
 
       context 'pack has no current rubocop todo' do
-        before { write_file('packs/my_pack/.rubocop.yml') }
+        before { write_file('packs/my_pack/package_rubocop.yml') }
 
         it 'creates the TODO' do
           expect(rubocop_todo_yml).to_not exist
@@ -278,8 +278,8 @@ RSpec.describe RuboCop::Packs do
           expect(rubocop_todo_yml).to exist
           expect(YAML.load_file(rubocop_todo_yml)).to eq(
             {
-              'Packs/RootNamespaceIsPackName' => { 'Exclude' => ['path/to/file.rb'] },
-              'Packs/ClassMethodsAsPublicApis' => { 'Exclude' => ['path/to/file.rb'] }
+              'Packs/RootNamespaceIsPackName' => { 'Exclude' => ['packs/my_pack/path/to/file.rb'] },
+              'Packs/ClassMethodsAsPublicApis' => { 'Exclude' => ['packs/my_pack/path/to/file.rb'] }
             }
           )
         end
@@ -298,12 +298,12 @@ RSpec.describe RuboCop::Packs do
           rubocop_todo_yml.write(
             YAML.dump(
               {
-                'Packs/RootNamespaceIsPackName' => { 'Exclude' => ['path/to/existing_file.rb'] },
-                'Packs/TypedPublicApis' => { 'Exclude' => ['path/to/file.rb'] }
+                'Packs/RootNamespaceIsPackName' => { 'Exclude' => ['packs/my_pack/path/to/existing_file.rb'] },
+                'Packs/TypedPublicApis' => { 'Exclude' => ['packs/my_pack/path/to/file.rb'] }
               }
             )
           )
-          write_file('packs/my_pack/.rubocop.yml')
+          write_file('packs/my_pack/package_rubocop.yml')
         end
 
         it 'adds to the TODO with the new files' do
@@ -312,9 +312,9 @@ RSpec.describe RuboCop::Packs do
           expect(rubocop_todo_yml).to exist
           expect(YAML.load_file(rubocop_todo_yml)).to eq(
             {
-              'Packs/RootNamespaceIsPackName' => { 'Exclude' => ['path/to/existing_file.rb', 'path/to/file.rb'] },
-              'Packs/TypedPublicApis' => { 'Exclude' => ['path/to/file.rb'] },
-              'Packs/ClassMethodsAsPublicApis' => { 'Exclude' => ['path/to/file.rb'] }
+              'Packs/RootNamespaceIsPackName' => { 'Exclude' => ['packs/my_pack/path/to/existing_file.rb', 'packs/my_pack/path/to/file.rb'] },
+              'Packs/TypedPublicApis' => { 'Exclude' => ['packs/my_pack/path/to/file.rb'] },
+              'Packs/ClassMethodsAsPublicApis' => { 'Exclude' => ['packs/my_pack/path/to/file.rb'] }
             }
           )
         end
@@ -322,9 +322,196 @@ RSpec.describe RuboCop::Packs do
     end
   end
 
+  describe 'pack_based_rubocop_config' do
+    let(:config) do
+      write_file('config/default.yml', <<~YML.strip)
+        <%= RuboCop::Packs.pack_based_rubocop_config(root_pathname: Pathname.pwd.to_s) %>
+      YML
+      YAML.safe_load(ERB.new(File.read('config/default.yml')).result(binding))
+    end
+
+    context 'no packs' do
+      it 'returns an empty YAML hash' do
+        expect(config).to eq({})
+      end
+    end
+
+    context 'one pack with exclude' do
+      before do
+        write_pack('packs/some_pack')
+
+        write_file('packs/some_pack/package_rubocop_todo.yml', <<~YML)
+          Packs/RootNamespaceIsPackName:
+            Exclude:
+              - 'packs/some_pack/app/services/bad_namespace.rb'
+        YML
+      end
+
+      it 'returns the pack\'s exclude' do
+        expect(config).to eq(
+          {
+            'Packs/RootNamespaceIsPackName' => {
+              'Exclude' => [
+                'packs/some_pack/app/services/bad_namespace.rb'
+              ]
+            }
+          }
+        )
+      end
+    end
+
+    context 'two packs with exclude' do
+      before do
+        write_pack('packs/some_pack')
+
+        write_file('packs/some_pack/package_rubocop_todo.yml', <<~YML)
+          Packs/RootNamespaceIsPackName:
+            Exclude:
+              - 'packs/some_pack/app/services/bad_namespace.rb'
+        YML
+
+        write_pack('packs/some_other_pack')
+
+        write_file('packs/some_other_pack/package_rubocop_todo.yml', <<~YML)
+          Packs/RootNamespaceIsPackName:
+            Exclude:
+              - 'packs/some_other_pack/app/services/bad_namespace.rb'
+        YML
+      end
+
+      it 'returns the pack\'s exclude' do
+        expect(config.keys).to eq(['Packs/RootNamespaceIsPackName'])
+        expect(config['Packs/RootNamespaceIsPackName'].keys).to eq(['Exclude'])
+        expect(config['Packs/RootNamespaceIsPackName']['Exclude'].sort).to eq(['packs/some_other_pack/app/services/bad_namespace.rb', 'packs/some_pack/app/services/bad_namespace.rb'])
+      end
+    end
+
+    context 'nested pack with child pack disabling rule but parent pack enabling rule' do
+      before do
+        write_pack('packs/parent_pack')
+
+        write_file('packs/parent_pack/package_rubocop.yml', <<~YML)
+          Packs/RootNamespaceIsPackName:
+            Enabled: true
+        YML
+
+        write_pack('packs/child_pack')
+
+        write_file('packs/child_pack/package_rubocop.yml', <<~YML)
+          Packs/RootNamespaceIsPackName:
+            Enabled: false
+        YML
+      end
+
+      it 'returns the pack\'s exclude' do
+        expect(config.keys).to eq(['Packs/RootNamespaceIsPackName'])
+        expect(config['Packs/RootNamespaceIsPackName']['Include'].sort).to include('packs/parent_pack/**/*')
+        expect(config['Packs/RootNamespaceIsPackName']['Exclude'].sort).to include('packs/child_pack/**/*')
+      end
+    end
+
+    context 'one pack with include' do
+      before do
+        write_pack('packs/some_pack')
+
+        write_file('packs/some_pack/package_rubocop.yml', <<~YML)
+          Packs/RootNamespaceIsPackName:
+            Enabled: true
+        YML
+      end
+
+      it 'returns a config with the right packs in the include field' do
+        expect(config).to eq(
+          {
+            'Packs/RootNamespaceIsPackName' => {
+              'Include' => [
+                'packs/some_pack/**/*'
+              ]
+            }
+          }
+        )
+      end
+    end
+
+    context 'three packs with include' do
+      before do
+        write_pack('packs/some_pack')
+
+        write_file('packs/some_pack/package_rubocop.yml', <<~YML)
+          Packs/RootNamespaceIsPackName:
+            Enabled: false
+        YML
+
+        write_pack('packs/some_other_pack')
+
+        write_file('packs/some_other_pack/package_rubocop.yml', <<~YML)
+          Packs/RootNamespaceIsPackName:
+            Enabled: true
+        YML
+
+        write_pack('packs/yet_another_pack')
+
+        write_file('packs/yet_another_pack/package_rubocop.yml', <<~YML)
+          Packs/RootNamespaceIsPackName:
+            Enabled: true
+        YML
+      end
+
+      it 'returns a config with the right packs in the include field' do
+        expect(config.keys).to eq(['Packs/RootNamespaceIsPackName'])
+        expect(config['Packs/RootNamespaceIsPackName'].keys).to eq(%w[Include Exclude])
+        expect(config['Packs/RootNamespaceIsPackName']['Include'].sort).to eq(['packs/some_other_pack/**/*', 'packs/yet_another_pack/**/*'])
+      end
+    end
+
+    context 'packs with inclusions and exclusions' do
+      before do
+        write_pack('packs/some_pack')
+
+        write_file('packs/some_pack/package_rubocop.yml', <<~YML)
+          Packs/RootNamespaceIsPackName:
+            Enabled: false
+        YML
+
+        write_pack('packs/some_other_pack')
+
+        write_file('packs/some_other_pack/package_rubocop.yml', <<~YML)
+          Packs/RootNamespaceIsPackName:
+            Enabled: true
+        YML
+
+        write_file('packs/some_other_pack/package_rubocop_todo.yml', <<~YML)
+          Packs/RootNamespaceIsPackName:
+            Exclude:
+              - packs/some_other_pack/my_file.rb
+        YML
+
+        write_pack('packs/yet_another_pack')
+
+        write_file('packs/yet_another_pack/package_rubocop.yml', <<~YML)
+          Packs/RootNamespaceIsPackName:
+            Enabled: true
+        YML
+
+        write_file('packs/yet_another_pack/package_rubocop_todo.yml', <<~YML)
+          Packs/RootNamespaceIsPackName:
+            Exclude:
+              - packs/yet_another_pack/my_file.rb
+        YML
+      end
+
+      it 'correctly merges into a single rule specification' do
+        expect(config.keys).to eq(['Packs/RootNamespaceIsPackName'])
+        expect(config['Packs/RootNamespaceIsPackName'].keys.sort).to eq(%w[Exclude Include])
+        expect(config['Packs/RootNamespaceIsPackName']['Include'].sort).to eq(['packs/some_other_pack/**/*', 'packs/yet_another_pack/**/*'])
+        expect(config['Packs/RootNamespaceIsPackName']['Exclude'].sort).to eq(['packs/some_other_pack/my_file.rb', 'packs/some_pack/**/*', 'packs/yet_another_pack/my_file.rb'])
+      end
+    end
+  end
+
   describe 'validations' do
     let(:errors) { RuboCop::Packs.validate }
-    describe 'pack based .rubocop_todo.yml files' do
+    describe 'pack based package_rubocop_todo.yml files' do
       context 'no packs' do
         it 'returns an empty list' do
           expect(errors).to be_empty
@@ -337,7 +524,7 @@ RSpec.describe RuboCop::Packs do
 
           write_file('packs/some_pack/app/services/bad_namespace.rb', '')
 
-          write_file('packs/some_pack/.rubocop_todo.yml', <<~YML)
+          write_file('packs/some_pack/package_rubocop_todo.yml', <<~YML)
             Packs/RootNamespaceIsPackName:
               Exclude:
                 - 'packs/some_pack/app/services/bad_namespace.rb'
@@ -353,7 +540,7 @@ RSpec.describe RuboCop::Packs do
         before do
           write_pack('packs/some_pack')
 
-          write_file('packs/some_pack/.rubocop_todo.yml', <<~YML)
+          write_file('packs/some_pack/package_rubocop_todo.yml', <<~YML)
             Packs/RootNamespaceIsPackName:
               Exclude:
                 - 'packs/some_pack/app/services/bad_namespace.rb'
@@ -368,7 +555,7 @@ RSpec.describe RuboCop::Packs do
       context 'one pack with disallowed cop key' do
         before do
           write_pack('packs/some_pack')
-          write_file('packs/some_pack/.rubocop_todo.yml', <<~YML)
+          write_file('packs/some_pack/package_rubocop_todo.yml', <<~YML)
             SomeOtherCop:
               Exclude:
                 - 'packs/some_pack/app/services/bad_namespace.rb'
@@ -377,9 +564,9 @@ RSpec.describe RuboCop::Packs do
 
         it 'returns an error' do
           error = <<~ERROR
-            packs/some_pack/.rubocop_todo.yml contains invalid configuration for SomeOtherCop.
+            packs/some_pack/package_rubocop_todo.yml contains invalid configuration for SomeOtherCop.
             Please only configure the following cops on a per-pack basis: ["Packs/RootNamespaceIsPackName", "Packs/TypedPublicApis", "Packs/ClassMethodsAsPublicApis"]"
-            For ignoring other cops, please instead modify the top-level .rubocop_todo.yml file.
+            For ignoring other cops, please instead modify the top-level package_rubocop_todo.yml file.
           ERROR
           expect(errors).to eq([error])
         end
@@ -388,7 +575,7 @@ RSpec.describe RuboCop::Packs do
       context 'one pack with disallowed configuration key' do
         before do
           write_pack('packs/some_pack')
-          write_file('packs/some_pack/.rubocop_todo.yml', <<~YML)
+          write_file('packs/some_pack/package_rubocop_todo.yml', <<~YML)
             Packs/RootNamespaceIsPackName:
               SomethingElse:
                 - 'packs/some_pack/app/services/bad_namespace.rb'
@@ -397,7 +584,7 @@ RSpec.describe RuboCop::Packs do
 
         it 'returns an error' do
           error = <<~ERROR
-            packs/some_pack/.rubocop_todo.yml contains invalid configuration for Packs/RootNamespaceIsPackName.
+            packs/some_pack/package_rubocop_todo.yml contains invalid configuration for Packs/RootNamespaceIsPackName.
             Please ensure the only configuration for Packs/RootNamespaceIsPackName is `Exclude`
           ERROR
           expect(errors).to eq([error])
@@ -410,7 +597,7 @@ RSpec.describe RuboCop::Packs do
 
           write_pack('packs/some_other_pack')
 
-          write_file('packs/some_pack/.rubocop_todo.yml', <<~YML)
+          write_file('packs/some_pack/package_rubocop_todo.yml', <<~YML)
             Packs/RootNamespaceIsPackName:
               Exclude:
                 - 'packs/some_other_pack/app/services/bad_namespace.rb'
@@ -419,7 +606,7 @@ RSpec.describe RuboCop::Packs do
 
         it 'returns an error' do
           error = <<~ERROR
-            packs/some_pack/.rubocop_todo.yml contains invalid configuration for Packs/RootNamespaceIsPackName.
+            packs/some_pack/package_rubocop_todo.yml contains invalid configuration for Packs/RootNamespaceIsPackName.
             packs/some_other_pack/app/services/bad_namespace.rb does not belong to packs/some_pack. Please ensure you only add exclusions
             for files within this pack.
           ERROR
@@ -432,28 +619,34 @@ RSpec.describe RuboCop::Packs do
         before do
           write_pack('packs/some_pack')
 
-          write_file('packs/some_pack/.rubocop.yml', <<~YML)
+          write_file('packs/some_pack/package_rubocop.yml', <<~YML)
             inherit_from: "something_else.yml"
           YML
         end
 
-        it 'returns an empty list' do
-          expect(errors).to be_empty
+        it 'has an error' do
+          error = <<~ERROR
+            packs/some_pack/package_rubocop.yml contains invalid configuration for inherit_from.
+            Please only configure the following cops on a per-pack basis: ["Packs/RootNamespaceIsPackName", "Packs/TypedPublicApis", "Packs/ClassMethodsAsPublicApis"]"
+            For ignoring other cops, please instead modify the top-level .rubocop.yml file.
+          ERROR
+
+          expect(errors).to eq([error])
         end
       end
     end
 
-    describe 'pack based .rubocop.yml files' do
+    describe 'pack based package_rubocop.yml files' do
       context 'no packs' do
         it 'returns an empty list' do
           expect(errors).to be_empty
         end
       end
 
-      context 'one pack with valid .rubocop.yml' do
+      context 'one pack with valid package_rubocop.yml' do
         before do
           write_pack('packs/some_pack')
-          write_file('packs/some_pack/.rubocop.yml', <<~YML)
+          write_file('packs/some_pack/package_rubocop.yml', <<~YML)
             Packs/RootNamespaceIsPackName:
               Enabled: true
           YML
@@ -464,10 +657,10 @@ RSpec.describe RuboCop::Packs do
         end
       end
 
-      context 'one pack with valid .rubocop.yml with FailureMode specified' do
+      context 'one pack with valid package_rubocop.yml with FailureMode specified' do
         before do
           write_pack('packs/some_pack')
-          write_file('packs/some_pack/.rubocop.yml', <<~YML)
+          write_file('packs/some_pack/package_rubocop.yml', <<~YML)
             Packs/RootNamespaceIsPackName:
               Enabled: true
               FailureMode: strict
@@ -482,7 +675,7 @@ RSpec.describe RuboCop::Packs do
       context 'one pack with disallowed cop key' do
         before do
           write_pack('packs/some_pack')
-          write_file('packs/some_pack/.rubocop.yml', <<~YML)
+          write_file('packs/some_pack/package_rubocop.yml', <<~YML)
             SomeOtherCop:
               Enabled: true
           YML
@@ -490,7 +683,7 @@ RSpec.describe RuboCop::Packs do
 
         it 'returns an error' do
           error = <<~ERROR
-            packs/some_pack/.rubocop.yml contains invalid configuration for SomeOtherCop.
+            packs/some_pack/package_rubocop.yml contains invalid configuration for SomeOtherCop.
             Please only configure the following cops on a per-pack basis: ["Packs/RootNamespaceIsPackName", "Packs/TypedPublicApis", "Packs/ClassMethodsAsPublicApis"]"
             For ignoring other cops, please instead modify the top-level .rubocop.yml file.
           ERROR
@@ -501,7 +694,7 @@ RSpec.describe RuboCop::Packs do
       context 'one pack with disallowed configuration key' do
         before do
           write_pack('packs/some_pack')
-          write_file('packs/some_pack/.rubocop.yml', <<~YML)
+          write_file('packs/some_pack/package_rubocop.yml', <<~YML)
             Packs/RootNamespaceIsPackName:
               Exclude:
                 - 'packs/some_pack/app/services/bad_namespace.rb'
@@ -510,7 +703,7 @@ RSpec.describe RuboCop::Packs do
 
         it 'returns an error' do
           error = <<~ERROR
-            packs/some_pack/.rubocop.yml contains invalid configuration for Packs/RootNamespaceIsPackName.
+            packs/some_pack/package_rubocop.yml contains invalid configuration for Packs/RootNamespaceIsPackName.
             Please ensure the only configuration for Packs/RootNamespaceIsPackName is `Enabled` and `FailureMode`
           ERROR
           expect(errors).to eq([error])
@@ -526,7 +719,7 @@ RSpec.describe RuboCop::Packs do
 
         before do
           write_pack('packs/some_pack')
-          write_file('packs/some_pack/.rubocop.yml', <<~YML)
+          write_file('packs/some_pack/package_rubocop.yml', <<~YML)
             Packs/RootNamespaceIsPackName:
               Enabled: true
           YML
@@ -534,14 +727,14 @@ RSpec.describe RuboCop::Packs do
 
         it 'returns an error' do
           error = <<~ERROR
-            packs/some_pack/.rubocop.yml is missing configuration for Packs/TypedPublicApis.
+            packs/some_pack/package_rubocop.yml is missing configuration for Packs/TypedPublicApis.
           ERROR
           expect(errors).to eq([error])
         end
       end
 
       # For now, this is allowed. We might add this restriction back once we've completed the migration off of `package_protections`
-      context 'one pack without a .rubocop.yml' do
+      context 'one pack without a package_rubocop.yml' do
         before do
           write_pack('packs/some_pack')
         end
@@ -554,19 +747,19 @@ RSpec.describe RuboCop::Packs do
 
     describe 'FailureMode: strict' do
       context 'package has specified FailureMode: strict for a cop' do
-        context 'package has pack-based .rubocop_todo.yml entries for that cop' do
+        context 'package has pack-based package_rubocop_todo.yml entries for that cop' do
           before do
             write_pack('packs/some_pack')
 
             write_file('packs/some_pack/app/services/some_file.rb', '')
 
-            write_file('packs/some_pack/.rubocop.yml', <<~YML)
+            write_file('packs/some_pack/package_rubocop.yml', <<~YML)
               Packs/RootNamespaceIsPackName:
                 Enabled: true
                 FailureMode: strict
             YML
 
-            write_file('packs/some_pack/.rubocop_todo.yml', <<~YML)
+            write_file('packs/some_pack/package_rubocop_todo.yml', <<~YML)
               Packs/RootNamespaceIsPackName:
                 Exclude:
                   - 'packs/some_pack/app/services/some_file.rb'
@@ -575,24 +768,24 @@ RSpec.describe RuboCop::Packs do
 
           it 'returns an empty list' do
             expect(errors).to eq([
-                                   'packs/some_pack has set `Packs/RootNamespaceIsPackName` to `FailureMode: strict` in `packs/some_pack/.rubocop.yml`, forbidding new exceptions. Please either remove `packs/some_pack/app/services/some_file.rb` from the top-level and pack-specific `.rubocop_todo.yml` files or remove `FailureMode: strict`.'
+                                   'packs/some_pack has set `Packs/RootNamespaceIsPackName` to `FailureMode: strict` in `packs/some_pack/package_rubocop.yml`, forbidding new exceptions. Please either remove `packs/some_pack/app/services/some_file.rb` from the top-level and pack-specific `package_rubocop_todo.yml` files or remove `FailureMode: strict`.'
                                  ])
           end
         end
 
-        context 'package has top-level .rubocop_todo.yml entries for that cop' do
+        context 'package has top-level package_rubocop_todo.yml entries for that cop' do
           before do
             write_pack('packs/some_pack')
 
             write_file('packs/some_pack/app/services/some_file.rb', '')
 
-            write_file('packs/some_pack/.rubocop.yml', <<~YML)
+            write_file('packs/some_pack/package_rubocop.yml', <<~YML)
               Packs/RootNamespaceIsPackName:
                 Enabled: true
                 FailureMode: strict
             YML
 
-            write_file('.rubocop_todo.yml', <<~YML)
+            write_file('package_rubocop_todo.yml', <<~YML)
               Packs/RootNamespaceIsPackName:
                 Exclude:
                   - 'packs/some_pack/app/services/some_file.rb'
@@ -601,7 +794,7 @@ RSpec.describe RuboCop::Packs do
 
           it 'returns an empty list' do
             expect(errors).to eq([
-                                   'packs/some_pack has set `Packs/RootNamespaceIsPackName` to `FailureMode: strict` in `packs/some_pack/.rubocop.yml`, forbidding new exceptions. Please either remove `packs/some_pack/app/services/some_file.rb` from the top-level and pack-specific `.rubocop_todo.yml` files or remove `FailureMode: strict`.'
+                                   'packs/some_pack has set `Packs/RootNamespaceIsPackName` to `FailureMode: strict` in `packs/some_pack/package_rubocop.yml`, forbidding new exceptions. Please either remove `packs/some_pack/app/services/some_file.rb` from the top-level and pack-specific `package_rubocop_todo.yml` files or remove `FailureMode: strict`.'
                                  ])
           end
         end


### PR DESCRIPTION
This reverts commit 8c4738f3737b37d75626d0684b279b19f4a1f49d.

It turns out per-pack rubocop configs have performance and blocking UX issues when using the new approach. Specifically, all paths in the root `.rubocop.yml` cannot reference pack specific paths as expectd. e.g. if a cop applies to `packs/my_pack`, within `packs/my_pack`, it will be considered to apply to `packs/my_pack/packs/my_pack`. This is not what is expected right now so we'll need to pursue another route if we want to still make this happen.
