### PR TITLE
Revert "fix: Remove `inherit_from` in `default.yml` that prevent merging custom configurations (#57)"

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -29,9 +29,4 @@ PackwerkLite/Dependency:
   Enabled: false
 
 # We do this inherit *after* setting the defaults so that pack-specific rubocops can override the defaults
-# Relevant documentation:
-#  - Inheriting config from a gem:
-#    - https://docs.rubocop.org/rubocop/configuration.html#inheriting-configuration-from-a-dependency-gem
-#  - ERB in a .rubocop.yml file
-#    - https://docs.rubocop.org/rubocop/configuration.html#pre-processing
-<%= RuboCop::Packs.pack_based_rubocop_config %>
+inherit_from: ./pack_config.yml

--- a/config/pack_config.yml
+++ b/config/pack_config.yml
@@ -1,0 +1,6 @@
+# Relevant documentation:
+#  - Inheriting config from a gem:
+#    - https://docs.rubocop.org/rubocop/configuration.html#inheriting-configuration-from-a-dependency-gem
+#  - ERB in a .rubocop.yml file
+#    - https://docs.rubocop.org/rubocop/configuration.html#pre-processing
+<%= RuboCop::Packs.pack_based_rubocop_config %>

--- a/lib/rubocop/packs.rb
+++ b/lib/rubocop/packs.rb
@@ -17,6 +17,7 @@ module RuboCop
 
     PROJECT_ROOT   = T.let(Pathname.new(__dir__).parent.parent.expand_path.freeze, Pathname)
     CONFIG_DEFAULT = T.let(PROJECT_ROOT.join('config', 'default.yml').freeze, Pathname)
+    CONFIG         = T.let(YAML.safe_load(CONFIG_DEFAULT.read).freeze, T.untyped)
 
     private_constant(:CONFIG_DEFAULT, :PROJECT_ROOT)
 


### PR DESCRIPTION
This reverts commit 6543c48e0d1f34182355006243f6b317894ed591.
