### PR TITLE
Fix bug with per-pack rubocop config

### DIFF
--- a/ADVANCED_USAGE.md
+++ b/ADVANCED_USAGE.md
@@ -9,6 +9,7 @@ In your top-level `.rubocop.yml` file, you'll want to include configuration from
 inherit_gem:
   rubocop-packs:
     - config/default.yml
+    - config/pack_config.yml
 ```
 
 This is the mechanism by which pack level rubocop files are incorporated into the top-level config.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-packs (0.0.37)
+    rubocop-packs (0.0.38)
       activesupport
       packs
       parse_packwerk

--- a/config/default.yml
+++ b/config/default.yml
@@ -27,11 +27,3 @@ PackwerkLite/Privacy:
 PackwerkLite/Dependency:
   # It is recommended to use packwerk
   Enabled: false
-
-# We do this inherit *after* setting the defaults so that pack-specific rubocops can override the defaults
-# Relevant documentation:
-#  - Inheriting config from a gem:
-#    - https://docs.rubocop.org/rubocop/configuration.html#inheriting-configuration-from-a-dependency-gem
-#  - ERB in a .rubocop.yml file
-#    - https://docs.rubocop.org/rubocop/configuration.html#pre-processing
-<%= RuboCop::Packs.pack_based_rubocop_config %>

--- a/config/erb_populated_data.yml
+++ b/config/erb_populated_data.yml
@@ -1,0 +1,7 @@
+# We do this inherit *after* setting the defaults so that pack-specific rubocops can override the defaults
+# Relevant documentation:
+#  - Inheriting config from a gem:
+#    - https://docs.rubocop.org/rubocop/configuration.html#inheriting-configuration-from-a-dependency-gem
+#  - ERB in a .rubocop.yml file
+#    - https://docs.rubocop.org/rubocop/configuration.html#pre-processing
+<%= RuboCop::Packs.pack_based_rubocop_config %>

--- a/config/pack_config.yml
+++ b/config/pack_config.yml
@@ -1,0 +1,6 @@
+# Relevant documentation:
+#  - Inheriting config from a gem:
+#    - https://docs.rubocop.org/rubocop/configuration.html#inheriting-configuration-from-a-dependency-gem
+#  - ERB in a .rubocop.yml file
+#    - https://docs.rubocop.org/rubocop/configuration.html#pre-processing
+inherit_from: ./erb_populated_data.yml

--- a/rubocop-packs.gemspec
+++ b/rubocop-packs.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   end
 
   # Specify which files should be added to the gem when it is released.
-  spec.files = Dir['README.md', 'lib/**/*', 'config/default.yml', 'config/pack_config.yml', 'config/pack_config.yml']
+  spec.files = Dir['README.md', 'lib/**/*', 'config/default.yml', 'config/pack_config.yml', 'config/erb_populated_data.yml']
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.7'
 

--- a/rubocop-packs.gemspec
+++ b/rubocop-packs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'rubocop-packs'
-  spec.version       = '0.0.37'
+  spec.version       = '0.0.38'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'A collection of Rubocop rules for gradually modularizing a ruby codebase'
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   end
 
   # Specify which files should be added to the gem when it is released.
-  spec.files = Dir['README.md', 'lib/**/*', 'config/default.yml', 'config/pack_config.yml']
+  spec.files = Dir['README.md', 'lib/**/*', 'config/default.yml', 'config/pack_config.yml', 'config/pack_config.yml']
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.7'
 


### PR DESCRIPTION
There was an issue with https://github.com/rubyatscale/rubocop-packs/pull/57/files that broke per-pack rubocop config.

I fix this here by allowing the client to explicitly require the capability for per-pack rubocop config.
