### PR TITLE
RootNamespaceIsPackName cop ignores spec/app files

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-packs (0.0.43)
+    rubocop-packs (0.0.44)
       activesupport
       packs-specification
       parse_packwerk

--- a/lib/rubocop/cop/packs/root_namespace_is_pack_name.rb
+++ b/lib/rubocop/cop/packs/root_namespace_is_pack_name.rb
@@ -34,8 +34,9 @@ module RuboCop
           relative_filepath = absolute_filepath.relative_path_from(Pathname.pwd)
           relative_filename = relative_filepath.to_s
 
-          # This cop only works for files ruby files in `app`
-          return if !relative_filename.include?('app/') || relative_filepath.extname != '.rb'
+          return if relative_filepath.extname != '.rb'
+          return if relative_filename.include?('spec/')
+          return if !relative_filename.include?('app/')
 
           relative_filename = relative_filepath.to_s
           package_for_path = ::Packs.for_file(relative_filename)

--- a/rubocop-packs.gemspec
+++ b/rubocop-packs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'rubocop-packs'
-  spec.version       = '0.0.43'
+  spec.version       = '0.0.44'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'A collection of Rubocop rules for gradually modularizing a ruby codebase'

--- a/spec/rubocop/cop/packs/root_namespace_is_pack_name_spec.rb
+++ b/spec/rubocop/cop/packs/root_namespace_is_pack_name_spec.rb
@@ -318,6 +318,19 @@ RSpec.describe RuboCop::Cop::Packs::RootNamespaceIsPackName, :config do
       end
     end
 
+    context 'file is a nested pack with spec/app path' do
+      let(:source) do
+        <<~RUBY
+          describe Forestry::Logging do
+          end
+        RUBY
+      end
+
+      it 'does not handle spec files and gracefully exits' do
+        expect_no_offenses source, Pathname.pwd.join(write_file('packs/fruits/apples/spec/app/services/forestry/logging.rb')).to_s
+      end
+    end
+
     context 'when file is in different namespace and is in lib' do
       let(:source) do
         <<~RUBY


### PR DESCRIPTION
Why is this change being made?
--------
`RootNamespaceIsPackName`'s intent is to only evaluate files under an `app` directory, which usually excludes specs. However, specs do get evaluated if their path includes `**/spec/app/**/*_spec.rb`.

This bug was surfaced when nesting a pack that also contains `spec/app` specs. `RootNamespaceIsPackName` reported a violation because the file's [namespace](https://github.com/rubyatscale/rubocop-packs/blob/c35a6ea954ed2f7f4b392457f41d16b9182ef81f/lib/rubocop/cop/packs/root_namespace_is_pack_name/desired_zeitwerk_api.rb#L78) was incorrectly calculated. [This](https://github.com/rubyatscale/rubocop-packs/blob/c35a6ea954ed2f7f4b392457f41d16b9182ef81f/lib/rubocop/cop/packs/root_namespace_is_pack_name/desired_zeitwerk_api.rb#L51) gsub was not designed to handle `spec/app/`.

What is this change doing?
--------
`RootNamespaceIsPackName` will now also ignore specs under an `app` directory.


How did you test this change?
--------
rspec

Fixes: https://github.com/Gusto/zenpayroll/issues/202967



