### PR TITLE
add bigdecimal and base64 to gemspec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     rubocop-packs (0.0.44)
       activesupport
+      bigdecimal
       packs-specification
       parse_packwerk
       rubocop (~> 1.0)
@@ -18,6 +19,7 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
     ast (2.4.2)
+    bigdecimal (3.1.6)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
     diff-lcs (1.5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,7 @@ PLATFORMS
   arm64-darwin-20
   arm64-darwin-21
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     rubocop-packs (0.0.44)
       activesupport
+      base64
       bigdecimal
       packs-specification
       parse_packwerk
@@ -19,6 +20,7 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
     ast (2.4.2)
+    base64 (0.2.0)
     bigdecimal (3.1.6)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)

--- a/rubocop-packs.gemspec
+++ b/rubocop-packs.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.7'
 
   spec.add_dependency 'activesupport'
+  spec.add_dependency 'bigdecimal'
   spec.add_dependency 'packs-specification'
   spec.add_dependency 'parse_packwerk'
   spec.add_dependency 'rubocop', '~> 1.0'

--- a/rubocop-packs.gemspec
+++ b/rubocop-packs.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.7'
 
   spec.add_dependency 'activesupport'
+  spec.add_dependency 'base64'
   spec.add_dependency 'bigdecimal'
   spec.add_dependency 'packs-specification'
   spec.add_dependency 'parse_packwerk'


### PR DESCRIPTION
As of Ruby 3.4, these are no longer part of the standard library and need to be explicitly required.

This should fix the initial build failures in https://github.com/rubyatscale/rubocop-packs/pull/73