### PR TITLE
More specific check for app/public/

### DIFF
--- a/lib/rubocop/cop/packs/class_methods_as_public_apis.rb
+++ b/lib/rubocop/cop/packs/class_methods_as_public_apis.rb
@@ -39,7 +39,7 @@ module RuboCop
         sig { params(node: T.untyped).void }
         def on_def(node)
           # This cop only applies for ruby files in `app/public`
-          return if !processed_source.file_path.include?('app/public')
+          return if !processed_source.file_path.include?('app/public/')
 
           # Looked at https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/MissingSuper source code as inspiration for htis part.
           class_node = node.each_ancestor(:class).first


### PR DESCRIPTION
Fix issue: Hardcoded reference to app/public is also too broad #71 - as an intermediate fix we're adding the following `/` so paths like `app/public_helpers` won't match anymore. 

In the future it would be better to match against the [public path specified for the pack](https://github.com/rubyatscale/packwerk-extensions/blob/4acb4d60f18b309b460234faaeedda0075083655/lib/packwerk/privacy/package.rb#L17)

Co-authored-by: Ashley Willard <ashley.willard@gusto.com>
Co-authored-by: Joey Schoblaska <joey.schoblaska@gusto.com>