### PR TITLE
notify via slack if main fails; add nightly job runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,5 +83,5 @@ jobs:
         with:
           payload: |
             {
-              "text": "${{ github.repository }}/${{ github.ref }}: ${{ job.status }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "text": "${{ github.repository }}/${{ github.ref }}: FAILED\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
   pull_request:
   schedule:
     - cron: "0 0 * * *"
@@ -71,7 +73,7 @@ jobs:
           bundle exec rake generate_cops_documentation
   notify_on_failure:
     runs-on: ubuntu-latest
-    needs: [rpsec, static_type_check, rubocop, verify_documentation]
+    needs: [rspec, static_type_check, rubocop, verify_documentation]
     if: ${{ failure() }}
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
 
 jobs:
   rspec:
@@ -11,7 +15,7 @@ jobs:
           - 2.7
           # See comment comes from https://github.com/ruby/setup-ruby#matrix-of-ruby-versions
           # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-          - '3.0'
+          - "3.0"
           - 3.1
           - head
     env:
@@ -65,3 +69,17 @@ jobs:
         run: |
           bundle exec rake documentation_syntax_check
           bundle exec rake generate_cops_documentation
+  notify_on_failure:
+    runs-on: ubuntu-latest
+    needs: [rpsec, static_type_check, rubocop, verify_documentation]
+    if: ${{ failure() && github.ref == "refs/heads/main" }}
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+    steps:
+      - uses: slackapi/slack-github-action@v1.25.0
+        with:
+          payload: |
+            {
+              "text": "${{ github.repository }}/${{ github.ref }}: ${{ job.status }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+            }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
   notify_on_failure:
     runs-on: ubuntu-latest
     needs: [rspec, static_type_check, rubocop, verify_documentation]
-    if: ${{ failure() && github.ref == "refs/heads/main" }}
+    if: ${{ failure() && github.ref == 'refs/heads/main' }}
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,5 +83,5 @@ jobs:
         with:
           payload: |
             {
-              "text": "${{ github.repository }}/${{ github.ref }}: ${{ job.status }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+              "text": "${{ github.repository }}/${{ github.ref }}: ${{ job.status }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
   notify_on_failure:
     runs-on: ubuntu-latest
     needs: [rspec, static_type_check, rubocop, verify_documentation]
-    if: ${{ failure() }}
+    if: ${{ failure() && github.ref == "refs/heads/main" }}
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
   notify_on_failure:
     runs-on: ubuntu-latest
     needs: [rpsec, static_type_check, rubocop, verify_documentation]
-    if: ${{ failure() && github.ref == "refs/heads/main" }}
+    if: ${{ failure() }}
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/lib/rubocop/packs/private.rb
+++ b/lib/rubocop/packs/private.rb
@@ -9,7 +9,7 @@ module RuboCop
     module Private
       extend T::Sig
 
-      sig { void }
+      sig { returns(Integer) }
       def self.bust_cache!
         @loaded_client_configuration = nil
       end

--- a/lib/rubocop/packs/private.rb
+++ b/lib/rubocop/packs/private.rb
@@ -9,7 +9,7 @@ module RuboCop
     module Private
       extend T::Sig
 
-      sig { returns(Integer) }
+      sig { void }
       def self.bust_cache!
         @loaded_client_configuration = nil
       end


### PR DESCRIPTION
1. If there is a failure on main for any step in the CI workflow, notify us in our internal Slack channel
2. Run the CI workflow nightly to catch new issues introduced by Ruby version changes, like https://github.com/rubyatscale/rubocop-packs/pull/75