### PR TITLE
don't run deploy job if CI was scheduled

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,10 +5,11 @@ on:
     workflows: [CI]
     types: [completed]
     branches: [main]
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event != 'schedule' }}
     steps:
       - uses: actions/checkout@v3
       - name: Tag and Push Gem


### PR DESCRIPTION
With https://github.com/rubyatscale/rubocop-packs/pull/78 we're now running CI on a schedule. However, we don't want these scheduled CI runs to trigger a deploy - the CD workflow should only run after a merge to main.