### PR TITLE
use universal darwin platform

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,21 +7,5 @@ on:
     branches: [main]
 
 jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event != 'schedule' }}
-    steps:
-      - uses: actions/checkout@v3
-      - name: Tag and Push Gem
-        id: tag-and-push-gem
-        uses: discourse/publish-rubygems-action@v2
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          GIT_EMAIL: ${{secrets.GUSTO_GIT_EMAIL}}
-          GIT_NAME: ${{secrets.GUSTO_GIT_NAME}}
-          RUBYGEMS_API_KEY: ${{secrets.RUBYGEMS_API_KEY}}
-      - name: Create GitHub Release
-        run: gh release create v${{steps.tag-and-push-gem.outputs.gem_version}} --generate-notes
-        if: ${{ steps.tag-and-push-gem.outputs.new_version == 'true' }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  call-workflow-from-shared-config:
+    uses: rubyatscale/shared-config/.github/workflows/cd.yml@maing

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,12 @@ GEM
     sorbet (0.5.10479)
       sorbet-static (= 0.5.10479)
     sorbet-runtime (0.5.10479)
+    sorbet-static (0.5.10479-universal-darwin-14)
+    sorbet-static (0.5.10479-universal-darwin-15)
+    sorbet-static (0.5.10479-universal-darwin-16)
+    sorbet-static (0.5.10479-universal-darwin-17)
+    sorbet-static (0.5.10479-universal-darwin-18)
+    sorbet-static (0.5.10479-universal-darwin-19)
     sorbet-static (0.5.10479-universal-darwin-20)
     sorbet-static (0.5.10479-universal-darwin-21)
     sorbet-static (0.5.10479-universal-darwin-22)
@@ -123,10 +129,7 @@ GEM
       yard (>= 0.9)
 
 PLATFORMS
-  arm64-darwin-20
-  arm64-darwin-21
-  arm64-darwin-22
-  arm64-darwin-23
+  universal-darwin
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
- Adds the universal-darwin platform to hopefully stop the persistent sorbet-static bundler issues we run into
- updates `sorbet-static`