### PR TITLE
Fix TypedPublicApis compatibility with new Sorbet::StrictSigil

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 PATH
   remote: .
   specs:
-    rubocop-packs (0.0.44)
+    rubocop-packs (0.0.45)
       activesupport
       base64
       bigdecimal
       packs-specification
       parse_packwerk
       rubocop (~> 1.0)
-      rubocop-sorbet
+      rubocop-sorbet (>= 0.8.4)
       sorbet-runtime
 
 GEM
@@ -21,7 +21,7 @@ GEM
       tzinfo (~> 2.0)
     ast (2.4.2)
     base64 (0.2.0)
-    bigdecimal (3.1.6)
+    bigdecimal (3.1.8)
     concurrent-ruby (1.1.10)
     diff-lcs (1.5.1)
     erubi (1.13.0)
@@ -33,7 +33,8 @@ GEM
     packs-specification (0.0.10)
       sorbet-runtime
     parallel (1.25.1)
-    parse_packwerk (0.20.0)
+    parse_packwerk (0.26.0)
+      bigdecimal
       sorbet-runtime
     parser (3.3.4.0)
       ast (~> 2.4.1)
@@ -76,8 +77,8 @@ GEM
       activesupport
       bundler
       rubocop (>= 1.22.0)
-    rubocop-sorbet (0.7.3)
-      rubocop (>= 0.90.0)
+    rubocop-sorbet (0.8.5)
+      rubocop (>= 1)
     ruby-progressbar (1.11.0)
     sorbet (0.5.11492)
       sorbet-static (= 0.5.11492)

--- a/lib/rubocop/cop/packs/typed_public_apis.rb
+++ b/lib/rubocop/cop/packs/typed_public_apis.rb
@@ -34,8 +34,8 @@ module RuboCop
         #
         extend T::Sig
 
-        sig { params(processed_source: T.untyped).void }
-        def investigate(processed_source)
+        sig { void }
+        def on_new_investigation
           return unless processed_source.path.include?('app/public')
 
           super

--- a/rubocop-packs.gemspec
+++ b/rubocop-packs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'rubocop-packs'
-  spec.version       = '0.0.44'
+  spec.version       = '0.0.45'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'A collection of Rubocop rules for gradually modularizing a ruby codebase'
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'packs-specification'
   spec.add_dependency 'parse_packwerk'
   spec.add_dependency 'rubocop', '~> 1.0'
-  spec.add_dependency 'rubocop-sorbet'
+  spec.add_dependency 'rubocop-sorbet', '>= 0.8.4'
   spec.add_dependency 'sorbet-runtime'
 
   spec.add_development_dependency 'bundler', '~> 2.2.16'

--- a/tasks/cop_documentation.rake
+++ b/tasks/cop_documentation.rake
@@ -54,7 +54,7 @@ task generate_cops_documentation: :yard_for_generate_documentation do
     ]
     config = config.for_cop(cop)
     safe_auto_correct = config.fetch('SafeAutoCorrect', true)
-    autocorrect = if cop.new.support_autocorrect?
+    autocorrect = if cop.support_autocorrect?
                     "Yes #{'(Unsafe)' unless safe_auto_correct}"
                   else
                     'No'


### PR DESCRIPTION
After [this change](https://github.com/Shopify/rubocop-sorbet/pull/241), this cop needs to be updated to use the proper callback.