### PR TITLE
Fix typos and grammatical issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Just install the `rubocop-packs` gem
 ```sh
 gem install rubocop-packs
 ```
-or, if you use `Bundler`, add this line your application's `Gemfile`:
+or, if you use `Bundler`, add this line to your application's `Gemfile`:
 
 ```ruby
 gem 'rubocop-packs', require: false
@@ -31,6 +31,7 @@ require:
 Now you can run `rubocop` and it will automatically load the RuboCop Packs cops together with the standard cops.
 
 ## The Cops
+
 All cops are located under [`lib/rubocop/cop/packs`](lib/rubocop/cop/packs), and contain examples/documentation.
 
 In your `.rubocop.yml`, you may treat the Packs cops just like any other cop. For example:

--- a/lib/rubocop/cop/packs/class_methods_as_public_apis.rb
+++ b/lib/rubocop/cop/packs/class_methods_as_public_apis.rb
@@ -41,7 +41,7 @@ module RuboCop
           # This cop only applies for ruby files in `app/public`
           return if !processed_source.file_path.include?('app/public/')
 
-          # Looked at https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/MissingSuper source code as inspiration for htis part.
+          # Looked at https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/MissingSuper source code as inspiration for this part.
           class_node = node.each_ancestor(:class).first
           module_node = node.each_ancestor(:module).first
           parent_class = class_node&.parent_class || module_node&.parent

--- a/lib/rubocop/cop/packwerk_lite/constant_resolver.rb
+++ b/lib/rubocop/cop/packwerk_lite/constant_resolver.rb
@@ -29,7 +29,7 @@ module RuboCop
           def public_api?
             # PackwerkExtensions should have a method to take in a path and determine if the file is public.
             # For now we put it here and only support the public folder (and not specific private constants).
-            # However if we declare that dependency we may want to extract this into `rubocop-packwerk_lite` or something liek that!
+            # However if we declare that dependency we may want to extract this into `rubocop-packwerk_lite` or something like that!
             constant_definition_location.to_s.include?('/public/')
           end
 

--- a/lib/rubocop/cop/packwerk_lite/constant_resolver.rb
+++ b/lib/rubocop/cop/packwerk_lite/constant_resolver.rb
@@ -28,8 +28,8 @@ module RuboCop
           sig { returns(T::Boolean) }
           def public_api?
             # PackwerkExtensions should have a method to take in a path and determine if the file is public.
-            # For now we put it here and only support the public folder (and not specific private constants).
-            # However if we declare that dependency we may want to extract this into `rubocop-packwerk_lite` or something like that!
+            # For now, we put it here and only support the public folder (and not specific private constants).
+            # However, if we declare that dependency we may want to extract this into `rubocop-packwerk_lite` or something like that!
             constant_definition_location.to_s.include?('/public/')
           end
 
@@ -53,7 +53,7 @@ module RuboCop
               found_files = expected_containing_pack.directory.glob("app/*/#{expected_containing_pack_last_name}/#{expected_location_in_pack}.rb")
             end
 
-            # Because of how Zietwerk works, we know two things:
+            # Because of how Zeitwerk works, we know two things:
             # 1) Since namespaces map one to one with files, Zeitwerk does not permit multiple files to define the same fully-qualified class/module.
             # (Note it does permit multiple files to open up portions of other namespaces)
             # 2) If a file *could* define a fully qualified constant, then it *must* define that constant!

--- a/lib/rubocop/cop/packwerk_lite/privacy_checker.rb
+++ b/lib/rubocop/cop/packwerk_lite/privacy_checker.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module PackwerkLite
-      # This cop helps ensure that packs are using public API of other systems
+      # This cop helps ensure that packs are using the public API of other systems
       # The following examples assume this basic setup.
       #
       # @example

--- a/lib/rubocop/cop/packwerk_lite/privacy_checker.rb
+++ b/lib/rubocop/cop/packwerk_lite/privacy_checker.rb
@@ -52,7 +52,7 @@ module RuboCop
 
           constant_reference = ConstantResolver::ConstantReference.resolve(node, processed_source)
 
-          # If we can't determine a constant reference, we can just early return. This could be beacuse the constant is defined
+          # If we can't determine a constant reference, we can just early return. This could be because the constant is defined
           # in a gem OR because it's not abiding by the namespace convention we've established.
           return if constant_reference.nil?
           return if constant_reference.referencing_package.name == constant_reference.source_package.name


### PR DESCRIPTION
## Summary
- Fix typos: `htis` → `this`, `beacuse` → `because`, `liek` → `like` in source code comments
- Fix additional grammatical issues found in comments and documentation

## Changes
- Commit 1: Fix confirmed typos found by `typos` tool
- Commit 2: Additional grammar/prose improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)