### PR TITLE
Security: bump activesupport, addressable, json, mcp, yard

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (8.1.2)
+    activesupport (8.1.3)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.3.1)
@@ -28,7 +28,7 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
-    addressable (2.8.9)
+    addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
     base64 (0.3.0)
@@ -42,14 +42,14 @@ GEM
     erubi (1.13.1)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
-    json (2.18.1)
+    json (2.19.9)
     json-schema (6.1.0)
       addressable (~> 2.8)
       bigdecimal (>= 3.1, < 5)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
-    mcp (0.8.0)
+    mcp (0.9.2)
       json-schema (>= 4.1)
     minitest (6.0.2)
       drb (~> 2.0)
@@ -175,7 +175,7 @@ GEM
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
     uri (1.1.1)
-    yard (0.9.38)
+    yard (0.9.44)
     yard-sorbet (0.9.0)
       sorbet-runtime
       yard
@@ -195,6 +195,7 @@ DEPENDENCIES
   simplecov
   sorbet
   tapioca
+  yard (>= 0.9.42, < 0.10.0)
 
 BUNDLED WITH
   4.0.7

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,7 +195,6 @@ DEPENDENCIES
   simplecov
   sorbet
   tapioca
-  yard (>= 0.9.42, < 0.10.0)
 
 BUNDLED WITH
   4.0.7


### PR DESCRIPTION
## Summary

Security bumps for five dependencies with active CVEs/GHSA advisories.

| Gem | Old → New | GHSA | Severity |
|-----|-----------|------|----------|
| activesupport | 8.1.2 → 8.1.3 | GHSA-2j26-frm8-cmj9 | High |
| activesupport | 8.1.2 → 8.1.3 | GHSA-89vf-4333-qx8v | High |
| activesupport | 8.1.2 → 8.1.3 | GHSA-cg4j-q9v8-6v38 | Medium |
| addressable | 2.8.9 → 2.9.0 | GHSA-h27x-rffw-24p4 | High |
| json | 2.18.1 → 2.19.9 | GHSA-3m6g-2423-7cp3 | Medium |
| mcp | 0.8.0 → 0.9.2 | GHSA-qvqr-5cv7-wh35 | High |
| yard | 0.9.38 → 0.9.44 | GHSA-3jfp-46x4-xgfj | Medium |

All tests pass (rspec: 81 examples, 0 failures, 100% line coverage).