### PR TITLE
Require Ruby >= 3.3 and update CI Ruby versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,4 +197,4 @@ DEPENDENCIES
   tapioca
 
 BUNDLED WITH
-  4.0.7
+  4.0.15

--- a/rubocop-packs.gemspec
+++ b/rubocop-packs.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   # Specify which files should be added to the gem when it is released.
   spec.files = Dir['README.md', 'lib/**/*', 'config/default.yml']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 3.2'
+  spec.required_ruby_version = '>= 3.3'
 
   spec.add_dependency 'activesupport'
   spec.add_dependency 'base64'


### PR DESCRIPTION
## Summary

Bumps the minimum supported Ruby version to 3.3 (Ruby 3.2 is now EOL).

### Changes

- **`rubocop-packs.gemspec`**: bumped `required_ruby_version` from `>= 3.2` to `>= 3.3`.

### No changes needed elsewhere

- CI (`.github/workflows/ci.yml`) delegates the test matrix to `rubyatscale/shared-config`; its only inline `setup-ruby` step is already pinned to `3.3`.
- No `.ruby-version` / `.tool-versions` files exist.
- `.rubocop.yml` does not set `TargetRubyVersion`.
- README contains no explicit minimum-Ruby-version statement.

## Motivation

Resolves the Ruby version restrictions from rubyatscale/pack_stats#56, where continuing to support EOL Ruby forced the project to hold back on older/vulnerable transitive dependencies. Dropping EOL Ruby 3.2 lets the supported set track 3.3 and 3.4.



## Bundler

Also bumps `BUNDLED WITH` in `Gemfile.lock` to bundler **4.0.15** (latest). The previously pinned bundler version crashes on Ruby `head` (`NameError: uninitialized constant Pathname::SEPARATOR_PAT`) — see [this failing run](https://github.com/rubyatscale/code_manifest/actions/runs/28200903631/job/83539858239?pr=12). Pinning the current bundler resolves it.