### PR TITLE
Fix code scanning issues: CodeQL setup and workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   call-workflow-from-shared-config:
     uses: rubyatscale/shared-config/.github/workflows/ci.yml@main

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,44 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: '30 1 * * 0'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: ruby
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
- The Gusto enterprise-level security config (`Gusto Default Advanced Security`, enforced) disables code scanning **default (automatic) setup** org/enterprise-wide, which has left this repo's default CodeQL setup stuck erroring since the policy took effect. Adds `.github/workflows/codeql.yml`, an explicit **advanced setup** workflow that isn't subject to that policy — same fix as [rubyatscale/query_packwerk#37](https://github.com/rubyatscale/query_packwerk/pull/37).
- Resolves the `actions/missing-workflow-permissions` code scanning finding on `ci.yml`: the `call-workflow-from-shared-config` job (and any other jobs in this file) had no explicit `permissions` block, so it defaulted to the repository's token permissions. Adds a root-level `permissions: contents: read`, since the shared-config reusable workflow only checks out code and posts to a Slack webhook — same fix as [rubyatscale/query_packwerk#38](https://github.com/rubyatscale/query_packwerk/pull/38).

## Test plan
- [ ] Confirm the `CI` workflow still passes after merge
- [ ] Confirm the `CodeQL` workflow runs successfully on `main`
- [ ] Confirm the code scanning status page no longer reports configuration errors
