### PR TITLE
Use shared-config's reusable CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,33 +12,10 @@ on:
 
 jobs:
   analyze:
-    name: Analyze (${{ matrix.language }})
-    runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read
       security-events: write
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - language: actions
-            build-mode: none
-          - language: ruby
-            build-mode: none
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
-        with:
-          languages: ${{ matrix.language }}
-          build-mode: ${{ matrix.build-mode }}
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
-        with:
-          category: "/language:${{ matrix.language }}"
+    uses: rubyatscale/shared-config/.github/workflows/codeql.yml@main # zizmor: ignore[unpinned-uses] internal reusable workflow tracked at @main by convention so shared-config updates propagate automatically
+    with:
+      languages: '["actions","ruby"]'


### PR DESCRIPTION
## Summary
Replaces the full copy-pasted `codeql.yml` with a thin caller of `rubyatscale/shared-config/.github/workflows/codeql.yml@main` (rubyatscale/shared-config#29), passing this repo's language list (`["actions","ruby"]`) as input instead of a hardcoded matrix.

Functionally identical to the current workflow - same checkout/codeql-action SHAs, same `build-mode: none`, same permissions - but future fixes (like the stale version-comment cleanup in shared-config#28) now land once in shared-config instead of needing to be repeated by hand across every consuming repo.

## Test plan
- [x] `zizmor` and `actionlint` - 0 findings
- [ ] Confirm the CodeQL check still runs and passes on this PR