### PR TITLE
Fix DocumentedPublicApis crash on non-Node left siblings

### DIFF
--- a/lib/rubocop/cop/packs/documented_public_apis.rb
+++ b/lib/rubocop/cop/packs/documented_public_apis.rb
@@ -66,8 +66,17 @@ module RuboCop
 
         sig { params(node: T.untyped).returns(T::Boolean) }
         def node_is_sorbet_signature?(node)
+          # A sibling is not necessarily an AST node. It is a `Symbol` when a method definition is
+          # passed to a modifier, such as the `:private` in `private def foo`.
+          return false if !node.is_a?(RuboCop::AST::Node)
+
+          # A node's `source` is `nil` when it has no source range. That is the case for the empty
+          # `args` node of a block written without parameters, as in `Struct.new(:a) do ... end`,
+          # which is the left sibling of a method defined as the block's only statement.
+          node_source = node.source
+
           # Is there a better way to check if a node is a sorbet signature? Probably!
-          !!(node && (node.source.include?('sig do') || node.source.include?('sig {')))
+          !!(node_source && (node_source.include?('sig do') || node_source.include?('sig {')))
         end
       end
     end

--- a/lib/rubocop/cop/packs/documented_public_apis.rb
+++ b/lib/rubocop/cop/packs/documented_public_apis.rb
@@ -49,7 +49,10 @@ module RuboCop
 
           left_sibling = node.left_sibling
 
-          if left_sibling == :private_class_method
+          # A `Symbol` sibling means the definition was passed to a modifier, as in
+          # `private def foo` or `private_class_method def self.foo`, so both the sig and the
+          # documentation comment sit above the enclosing send rather than above the definition.
+          if left_sibling.is_a?(Symbol)
             if node_is_sorbet_signature?(node.parent.left_sibling)
               return if documentation_comment?(node.parent.left_sibling)
             elsif documentation_comment?(node.parent)

--- a/spec/rubocop/cop/packs/documented_public_apis_spec.rb
+++ b/spec/rubocop/cop/packs/documented_public_apis_spec.rb
@@ -187,6 +187,70 @@ RSpec.describe RuboCop::Cop::Packs::DocumentedPublicApis, :config do
     end
   end
 
+  context 'using inline private instance method syntax' do
+    context 'with a sig' do
+      context 'documented' do
+        let(:source) do
+          <<~RUBY
+            class Foo
+              # Here is documentation!
+              sig { void }
+              private def bar
+              end
+            end
+          RUBY
+        end
+
+        it { expect_no_offenses source, 'packs/foo/app/public/foo.rb' }
+      end
+
+      context 'undocumented' do
+        let(:source) do
+          <<~RUBY
+            class Foo
+              sig { void }
+              private def bar
+                      ^^^^^^^ Missing method documentation comment.
+              end
+            end
+          RUBY
+        end
+
+        it { expect_offense source, 'packs/foo/app/public/foo.rb' }
+      end
+    end
+
+    context 'with no sig' do
+      context 'documented' do
+        let(:source) do
+          <<~RUBY
+            class Foo
+              # Here is documentation!
+              private def bar
+              end
+            end
+          RUBY
+        end
+
+        it { expect_no_offenses source, 'packs/foo/app/public/foo.rb' }
+      end
+
+      context 'undocumented' do
+        let(:source) do
+          <<~RUBY
+            class Foo
+              private def bar
+                      ^^^^^^^ Missing method documentation comment.
+              end
+            end
+          RUBY
+        end
+
+        it { expect_offense source, 'packs/foo/app/public/foo.rb' }
+      end
+    end
+  end
+
   context 'when a method is defined inside a block' do
     context 'when the block takes no parameters and the method is undocumented' do
       let(:source) do

--- a/spec/rubocop/cop/packs/documented_public_apis_spec.rb
+++ b/spec/rubocop/cop/packs/documented_public_apis_spec.rb
@@ -186,4 +186,78 @@ RSpec.describe RuboCop::Cop::Packs::DocumentedPublicApis, :config do
       end
     end
   end
+
+  context 'when a method is defined inside a block' do
+    context 'when the block takes no parameters and the method is undocumented' do
+      let(:source) do
+        <<~RUBY
+          Foo = Struct.new(:a) do
+            def bar
+            ^^^^^^^ Missing method documentation comment.
+            end
+          end
+        RUBY
+      end
+
+      it { expect_offense source, 'packs/foo/app/public/foo.rb' }
+    end
+
+    context 'when the block takes no parameters and the method is documented' do
+      let(:source) do
+        <<~RUBY
+          Foo = Struct.new(:a) do
+            # This has documentation, cool
+            def bar
+            end
+          end
+        RUBY
+      end
+
+      it { expect_no_offenses source, 'packs/foo/app/public/foo.rb' }
+    end
+
+    context 'when the method has a sig and documentation above the sig' do
+      let(:source) do
+        <<~RUBY
+          Foo = Data.define(:a) do
+            # This has documentation, cool
+            sig { void }
+            def bar
+            end
+          end
+        RUBY
+      end
+
+      it { expect_no_offenses source, 'packs/foo/app/public/foo.rb' }
+    end
+
+    context 'when the method has a sig and no documentation' do
+      let(:source) do
+        <<~RUBY
+          Foo = Data.define(:a) do
+            sig { void }
+            def bar
+            ^^^^^^^ Missing method documentation comment.
+            end
+          end
+        RUBY
+      end
+
+      it { expect_offense source, 'packs/foo/app/public/foo.rb' }
+    end
+
+    context 'when the block takes parameters' do
+      let(:source) do
+        <<~RUBY
+          Foo = Struct.new(:a) do |klass|
+            def bar
+            ^^^^^^^ Missing method documentation comment.
+            end
+          end
+        RUBY
+      end
+
+      it { expect_offense source, 'packs/foo/app/public/foo.rb' }
+    end
+  end
 end


### PR DESCRIPTION
Fixes #101

## Summary

Two shapes of method definition made `Packs/DocumentedPublicApis` raise `NoMethodError` rather than report an offense. Both come from one assumption in `node_is_sorbet_signature?`, that a left sibling which is not `nil` is an AST node with source.

A method that is the leading statement of an argument-less block has the block's own empty `args` node as its sibling. That node has no source range, so `Node#source` returns `nil` and `nil.include?` raises. `Struct.new(:a) do`, `Data.define(:a) do` and `class_eval do` all hit it.

A method passed to a modifier other than `private_class_method` has a `Symbol` as its sibling, and `Symbol` has no `#source`.

The first commit guards against both. The second widens the existing `private_class_method` branch to any `Symbol` sibling, because otherwise the first commit converts the `private def` crash into a false positive: `documentation_comment?` looks up comments attached to the node it is handed, and for `private def foo` the comment attaches to the enclosing send, so a documented method gets flagged. That is the same reason #56 special-cased `private_class_method` in the first place.

**The second commit is independently droppable** if you would rather take only the crash fix.

## Motivation

Found on a pack whose public API is a set of `Data.define(...) do ... end` value objects with instance methods. The cop cannot evaluate any file using that idiom.

## Behaviour

Widening the branch to any `Symbol` is a superset of the old condition, so every input that took the old branch still takes it. The only newly routed inputs are the ones that used to raise. All 11 pre-existing examples keep byte-identical offense ranges.

One genuinely new behaviour worth flagging: a method defined on the right-hand side of an assignment now consults the comment above the assignment instead of raising, because a `casgn` also leaves a `Symbol` sibling.

## Tests

Nine new examples. Five cover methods inside blocks: argument-less and undocumented, argument-less and documented, a sig with documentation above it, a sig with no documentation, and a block that declares parameters as a regression guard. Four mirror the existing `private_class_method` matrix using `private def`.

## Notes

`manual/` is unchanged. The class docstring was not touched, and `tasks/cop_documentation.rake` renders only the docstring and its examples rather than method-body comments, so `CI=true VERIFYING_DOCUMENTATION=true bundle exec rake generate_cops_documentation` passes with no diff.

Verified locally: 90 examples and 0 failures at 100 percent line and branch coverage, `srb tc` clean, `rubocop` clean.

`main` has moved on from the released `v0.0.45`, so this needs a release before affected consumers can pick it up.

cc @alexevanczuk (wrote the `private_class_method` handling in #56) and @dduugg
